### PR TITLE
Fix .gitmodules file to use url https://github.com instead of git@github.com

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sst-dumpi"]
 	path = sst-dumpi
-	url = git@github.com:sstsimulator/sst-dumpi.git
+	url = https://github.com/sstsimulator/sst-dumpi.git


### PR DESCRIPTION
This avoids eliminates the download security issue for users without github credentials