### PR TITLE
Adding template files to sst-macro for information on pull requests and issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+New Issue for sst-macro
+-----------------------
+
+1 - Detailed description of problem or enhancement
+
+2 - Describe how to reproduce
+
+3 - What Operating system(s) and versions 
+
+4 - What version of external libraries (Boost, MPI)
+
+5 - Provide sha1 of all relevant sst repositories (sst-core, sst-elements, etc)
+
+6 - Fill out Labels, Milestones, and Assignee fields as best possible

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+Erase this information and put your Pull Request comments here 
+---
+
+Instructions for Issuing a Pull Request to sst-macro
+----------------------------------------------------
+
+1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-macro
+
+2 - Verify that Source branch is up to date with the devel branch of sst-macro
+
+3 - After submitting your Pull Request:
+   * Automatic Testing will commence in a short while 
+      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
+         * These branches are syncronized with the devel branch of sst-macro.  This is why is it important to keep your source branch up to date.
+      * If testing passes, the source branch will be automatically merged (if possible)
+         * Pull Requests from forks will not be automatically tested until the code is inspected.
+         * Pull Requests from forks will not be automatically merged into the devel branch.
+      * If testing fails, You will be notified of the test results.  
+         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
+         
+----


### PR DESCRIPTION
These are two new files in the .github directory.  They have no impact on existing sst-macro code.  These are only support files that GitHub will access to display information when a Pull Request or Issues is submitted.  Also note that these files only work against the default branch which is "master".  Until these files exist in the master branch, they will have no effect.