### PR TITLE
Don't include mpi.h in driver if you're not using mpi.

### DIFF
--- a/sstmac/main/driver.cc
+++ b/sstmac/main/driver.cc
@@ -13,7 +13,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#ifdef SSTMAC_HAVE_MPI_H
+#if SSTMAC_MPI_DRIVER
 #include <mpi.h>
 #endif
 


### PR DESCRIPTION
Fixed problem where mpi.h was included in driver.cc even though mpi wasn't being used.  Linking error occurred in this case.