### PR TITLE
Fixed an lib ordering issue that causes linking failure

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -51,9 +51,9 @@ sstmac_SOURCES = src/sstmac_dummy_main.cc
 sstmac_top_info_SOURCES = src/top_info.cc
 
 exe_LDADD = \
-    ../sprockit/sprockit/libsprockit.la \
     ../sstmac/main/libsstmac_main.la \
-    ../sstmac/install/libsstmac.la
+    ../sstmac/install/libsstmac.la \
+    ../sprockit/sprockit/libsprockit.la
 
 if EXTERNAL_BOOST
   exe_LDADD += $(BOOST_LDFLAGS)


### PR DESCRIPTION
Does not seem to be a problem for macs, does crop up on Ubuntu.