### PR TITLE
Change lib ordering to get linking working in Ubuntu 18.04 with GCC 7.1

### DIFF
--- a/tests/Makefile.check_programs
+++ b/tests/Makefile.check_programs
@@ -7,31 +7,31 @@ test_utilities_LDADD = $(CORE_LIBS)
 noinst_LTLIBRARIES = libsstmac_test_pthread.la
 test_pthread_SOURCES = dummy_pthread.cc
 libsstmac_test_pthread_la_SOURCES = test_pthread.cc
-test_pthread_LDADD = $(CORE_LIBS) \
+test_pthread_LDADD = $(top_builddir)/sstmac/main/libsstmac_main.la \
   libsstmac_test_pthread.la \
-  $(top_builddir)/sstmac/main/libsstmac_main.la
+  $(CORE_LIBS)
 
 noinst_LTLIBRARIES += libsstmac_test_blas.la
 test_blas_SOURCES = dummy_blas.cc
 libsstmac_test_blas_la_SOURCES = test_blas.cc
-test_blas_LDADD = $(CORE_LIBS) \
+test_blas_LDADD = libsstmac_test_blas.la \
   $(top_builddir)/sstmac/libraries/blas/libsstmac_blas.la \
   $(top_builddir)/sstmac/main/libsstmac_main.la \
-  libsstmac_test_blas.la
+  $(CORE_LIBS)
 
 noinst_LTLIBRARIES += libsstmac_test_std_thread.la
 test_std_thread_SOURCES = dummy_std_thread.cc
 libsstmac_test_std_thread_la_SOURCES = test_std_thread.cc
-test_std_thread_LDADD = $(CORE_LIBS) \
+test_std_thread_LDADD = libsstmac_test_std_thread.la \
   $(top_builddir)/sstmac/main/libsstmac_main.la \
-  libsstmac_test_std_thread.la
+  $(CORE_LIBS)
 
 noinst_LTLIBRARIES += libsstmac_test_tls.la
 test_tls_SOURCES = dummy_tls.cc
 libsstmac_test_tls_la_SOURCES = test_tls.cc
-test_tls_LDADD = $(CORE_LIBS) \
+test_tls_LDADD = libsstmac_test_tls.la \
   $(top_builddir)/sstmac/main/libsstmac_main.la \
-  libsstmac_test_tls.la
+  $(CORE_LIBS)
 
 if BUILD_SUMI_MPI
 check_PROGRAMS += test_scan test_uq

--- a/tests/api/globals/Makefile.am
+++ b/tests/api/globals/Makefile.am
@@ -25,9 +25,9 @@ EXTRA_DIST += testglobals.cc
 check_PROGRAMS = testexec
 testexec_SOURCES = exec.cc
 testexec_LDADD = \
-  $(top_builddir)/sprockit/sprockit/libsprockit.la \
+  $(top_builddir)/sstmac/main/libsstmac_main.la \
   $(top_builddir)/sstmac/install/libsstmac.la \
-  $(top_builddir)/sstmac/main/libsstmac_main.la
+  $(top_builddir)/sprockit/sprockit/libsprockit.la
 
 
 if EXTERNAL_BOOST

--- a/tests/api/mpi/Makefile.am
+++ b/tests/api/mpi/Makefile.am
@@ -33,8 +33,8 @@ else
 check_PROGRAMS = testexec
 testexec_SOURCES = exec.cc
 testexec_LDADD = \
-  $(top_builddir)/sstmac/install/libsstmac.la \
   $(top_builddir)/sstmac/main/libsstmac_main.la \
+  $(top_builddir)/sstmac/install/libsstmac.la \
   $(top_builddir)/sprockit/sprockit/libsprockit.la
 
 if EXTERNAL_BOOST

--- a/tests/external/Makefile.am
+++ b/tests/external/Makefile.am
@@ -33,8 +33,8 @@ if EXTERNAL_BOOST
 endif
 
 test_LDADD += \
-  $(top_builddir)/sstmac/install/libsstmac.la \
   $(top_builddir)/sstmac/main/libsstmac_main.la \
+  $(top_builddir)/sstmac/install/libsstmac.la \
   $(top_builddir)/sprockit/sprockit/libsprockit.la
 
 if USE_MPIPARALLEL

--- a/tests/sumi/Makefile.am
+++ b/tests/sumi/Makefile.am
@@ -24,9 +24,9 @@ AM_CPPFLAGS += -I$(top_builddir)/sstmac/replacements -I$(top_srcdir)/sstmac/repl
 AM_CPPFLAGS += -Dmain=USER_MAIN -DSSTMAC=1
 
 exe_LDADD = \
+  ../../sstmac/main/libsstmac_main.la \
   ../../sstmac/install/libsstmac.la \
-  ../../sprockit/sprockit/libsprockit.la \
-  ../../sstmac/main/libsstmac_main.la
+  ../../sprockit/sprockit/libsprockit.la
 
 exe_FLAGS = 
 

--- a/tests/unit_tests/Makefile.am
+++ b/tests/unit_tests/Makefile.am
@@ -42,9 +42,9 @@ test_unit_test_SOURCES = \
 
 
 TEST_LDFLAGS = \
+  util/libsstmac_unit_test_util.la \
   $(top_builddir)/sstmac/install/libsstmac.la \
-  $(top_builddir)/sprockit/sprockit/libsprockit.la \
-  util/libsstmac_unit_test_util.la
+  $(top_builddir)/sprockit/sprockit/libsprockit.la
 
 if EXTERNAL_BOOST
   TEST_LDFLAGS += $(BOOST_LDFLAGS)


### PR DESCRIPTION
Ubuntu 18.04 with GCC 7.1 has linker errors when running 'make check'. Fixed by changing library ordering.