### PR TITLE
get rid of type aliases for old ELI problem

### DIFF
--- a/sstmac/sst_core/integrated_component.h
+++ b/sstmac/sst_core/integrated_component.h
@@ -61,16 +61,6 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sst/core/elementinfo.h>
 #include <sst/core/component.h>
 
-using SST::ComponentId_t;
-using SST::Params;
-using SST::ComponentDoc;
-using SST::ElementInfoParam;
-using SST::ElementInfoPort2;
-using SST::ElementInfoStatistic;
-using SST::SST_ELI_getMajorNumberFromVersion;
-using SST::SST_ELI_getMinorNumberFromVersion;
-using SST::SST_ELI_getTertiaryNumberFromVersion;
-
 #define SSTMAC_VALID_PORTS \
    {"input %(out)d %(in)d",  "Will receive new payloads here",      {}}, \
    {"output %(out)d %(in)d", "Will receive new acks(credits) here", {}}, \


### PR DESCRIPTION
Fixes for problem with old ELI (not using fully scoped names in macros) are now referencing defunct names (which are not formally part of the API).  These need to be removed so we can update core.