### PR TITLE
Llvm quick bug fix

### DIFF
--- a/bin/clang/frontendActions.h
+++ b/bin/clang/frontendActions.h
@@ -65,7 +65,7 @@ class ReplaceAction : public clang::ASTFrontendAction {
   void EndSourceFileAction() override;
 
   std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance& CI, clang::StringRef file) override {
+  CreateASTConsumer(clang::CompilerInstance& CI, clang::StringRef /* file */) override {
     rewriter_.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
     visitor_.setCompilerInstance(CI);
     initPragmas(CI);

--- a/bin/clang/frontendActions.h
+++ b/bin/clang/frontendActions.h
@@ -75,11 +75,11 @@ class ReplaceAction : public clang::ASTFrontendAction {
  private:
   void initPragmas(clang::CompilerInstance& CI);
 
-  SkeletonASTVisitor visitor_;
   clang::Rewriter rewriter_;
   GlobalVarNamespace globalNs_;
-  clang::CompilerInstance* ci_;
+  clang::CompilerInstance* ci_ = nullptr;
   PragmaConfig prgConfig_;
+  SkeletonASTVisitor visitor_;
 };
 
 #endif

--- a/bin/clang/pragmas.h
+++ b/bin/clang/pragmas.h
@@ -57,8 +57,6 @@ struct SSTReplacePragma;
 struct SSTNullVariablePragma;
 struct SSTNullVariableGeneratorPragma;
 struct PragmaConfig {
-  int pragmaDepth;
-  bool makeNoChanges;
   std::map<std::string,SSTReplacePragma*> replacePragmas;
   std::map<clang::Decl*,SSTNullVariablePragma*> nullVariables;
   std::map<clang::FunctionDecl*,std::set<SSTPragma*>> functionPragmas;
@@ -66,14 +64,15 @@ struct PragmaConfig {
   std::set<const clang::DeclRefExpr*> deletedRefs;
   std::set<std::string> newParams;
   std::string dependentScopeGlobal;
-  SkeletonASTVisitor* astVisitor;
-  PragmaConfig() : pragmaDepth(0),
-    makeNoChanges(false),
-    nullifyDeclarationsPragma(nullptr)
-  {}
   std::string computeMemorySpec;
   std::list<std::pair<SSTNullVariablePragma*,clang::TypedefDecl*>> pendingTypedefs;
-  SSTNullVariableGeneratorPragma* nullifyDeclarationsPragma;
+
+  int pragmaDepth = 0;
+  bool makeNoChanges = false;
+  SkeletonASTVisitor* astVisitor = nullptr;
+  SSTNullVariableGeneratorPragma* nullifyDeclarationsPragma = nullptr;
+
+  PragmaConfig() = default; 
 };
 
 struct SSTPragmaList;


### PR DESCRIPTION
Fixed an initialization order bug in the llvm section. 

Also commented out an unused variable to silence a warning. 