### PR TITLE
Removed random_shuffle from macro

### DIFF
--- a/sstmac/software/launch/random_allocation.cc
+++ b/sstmac/software/launch/random_allocation.cc
@@ -83,7 +83,7 @@ RandomAllocation::allocate(
   std::vector<NodeId> availvec(available.size());
   std::copy(available.begin(), available.end(), availvec.begin());
   RNG::UniformInteger_functor rngf(rng_);
-  std::random_shuffle(availvec.begin(), availvec.end(), rngf);
+  RNG::random_shuffle(availvec.begin(), availvec.end(), rngf);
   for (int i = 0; i < nnode_requested; i++) {
     NodeId node = availvec[i];
     allocation.insert(node);

--- a/sstmac/software/launch/random_task_mapper.cc
+++ b/sstmac/software/launch/random_task_mapper.cc
@@ -86,7 +86,7 @@ RandomTaskMapper::mapRanks(
   }
 
   RNG::UniformInteger_functor rngf(rng_);
-  std::random_shuffle(result.begin(), result.end(), rngf);
+  RNG::random_shuffle(result.begin(), result.end(), rngf);
 
   result.resize(nproc);
 }


### PR DESCRIPTION
Also new random_shuffle actually does what you think it does, gives the same result regardless of the platform.

This should close #443, it removes std::random_shuffle and also makes the shuffling deterministic if you give it a deterministic UniformInteger_functor. 