### PR TITLE
Clang format474

### DIFF
--- a/bin/sstccvars.py.in
+++ b/bin/sstccvars.py.in
@@ -8,6 +8,7 @@ clangCppFlagsStr="@CLANG_CPPFLAGS@"
 clangLdFlagsStr="@CLANG_LDFLAGS@"
 clangLibtoolingCxxFlagsStr="@CLANG_LIBTOOLING_CXX_FLAGS@"
 clangLibtoolingCFlagsStr="@CLANG_LIBTOOLING_C_FLAGS@"
+clangBin="@CLANG_INSTALL_DIR@"
 
 sstCppFlags = [
 "@SST_CPPFLAGS@",
@@ -32,7 +33,6 @@ sstCxxFlagsStr="@CXXFLAGS@ @SST_CXXFLAGS@"
 sstCFlagsStr="@CFLAGS@"
 cc="@CC@"
 cxx="@CXX@"
-
 
 # Configure the PYTHONPATH
 def setPythonPath():

--- a/sstmac/Makefile.am
+++ b/sstmac/Makefile.am
@@ -22,8 +22,9 @@ STD_SUBDIRS = \
   skeletons \
   test_skeletons \
   sst_core \
-  llvm \
   install 
+
+# llvm 
 
 library_includedir=$(includedir)/sstmac
 


### PR DESCRIPTION
Attempts to close #474, and changes the clean up of temps so that you won't have temporary object files unless you want them. 