### PR TITLE
Compiler 485

### DIFF
--- a/tests/clang_src2src/deglobal_array.cc
+++ b/tests/clang_src2src/deglobal_array.cc
@@ -5,13 +5,14 @@ int xx[42];
 namespace y {
   int x[] = {1,2};
   int xx[42];
+  const int cxx[] = {1,2,3};
 }
 
 void fxn()
 {
   int* z = x;
   int* zz = y::x;
-  y::xx[0] = 0;
+  y::xx[0] = y::cxx[0];
   xx[0] = 0;
 }
 

--- a/tests/reference/test_clang_deglobal_array_cpp.ref-out
+++ b/tests/reference/test_clang_deglobal_array_cpp.ref-out
@@ -5,13 +5,14 @@ int xx[42];typedef int array_type_xx[42];extern int __offset_xx; int __sizeof_xx
 namespace y {
   int x[] = {1,2};typedef int array_type_x[2];extern int __offset_x; int __sizeof_x = sizeof(::y::array_type_x);static std::function<void(void*)> init_x = [](void* ptr){ new (ptr) ::y::array_type_x{1, 2}; };sstmac::CppGlobalRegisterGuard x_sstmac_ctor(__offset_x, __sizeof_x, false, "x", std::move(init_x));
   int xx[42];typedef int array_type_xx[42];extern int __offset_xx; int __sizeof_xx = sizeof(::y::array_type_xx);static std::function<void(void*)> init_xx = [](void* ptr){ new (ptr) ::y::array_type_xx; };sstmac::CppGlobalRegisterGuard xx_sstmac_ctor(__offset_xx, __sizeof_xx, false, "xx", std::move(init_xx));
+  const int cxx[] = {1,2,3};
 }
 
 void fxn()
 { char* sstmac_global_data = get_sstmac_global_data();array_type_x* sstmac_x=(array_type_x*)(sstmac_global_data + __offset_x); array_type_xx* sstmac_xx=(array_type_xx*)(sstmac_global_data + __offset_xx); ::y::array_type_x* __y__sstmac_x=(::y::array_type_x*)(sstmac_global_data + ::y::__offset_x); ::y::array_type_xx* __y__sstmac_xx=(::y::array_type_xx*)(sstmac_global_data + ::y::__offset_xx); {
   int* z = (*sstmac_x);
   int* zz = (*__y__sstmac_x);
-  (*__y__sstmac_xx)[0] = 0;
+  (*__y__sstmac_xx)[0] = y::cxx[0];
   (*sstmac_xx)[0] = 0;
  }}
 #include <sstmac/software/process/cppglobal.h>


### PR DESCRIPTION
Added an extra bit of code to the source to source deglobalizer to check for const C style arrays in a namespace as well as non-const ones. 