### PR TITLE
Remove warnings

### DIFF
--- a/bin/clang/astVisitor.cc
+++ b/bin/clang/astVisitor.cc
@@ -1865,13 +1865,13 @@ SkeletonASTVisitor::finalize()
   for (auto& pair : declsToInsertAfter_){
     auto& declPair = pair.second;
 
-    bool hasTypeDecl = false;
     clang::VarDecl* D = declPair.first;
 
     SourceLocation declEnd = getEndLoc(getEnd(D));
     rewriter_.InsertText(declEnd, declPair.second);
 
     /**
+    bool hasTypeDecl = false;
     auto ty = D->getType().getTypePtr();
     if (ty->isStructureType()){
       RecordDecl* recDecl = ty->getAsStructureType()->getDecl();

--- a/bin/clang/astVisitor.cc
+++ b/bin/clang/astVisitor.cc
@@ -427,19 +427,19 @@ SkeletonASTVisitor::shouldVisitDecl(VarDecl* D)
 
 
 bool
-SkeletonASTVisitor::VisitCXXNewExpr(CXXNewExpr *expr)
+SkeletonASTVisitor::VisitCXXNewExpr(CXXNewExpr * /*expr*/)
 {
   return true; //don't do this anymore
 }
 
 bool
-SkeletonASTVisitor::TraverseDecltypeTypeLoc(clang::DecltypeTypeLoc loc)
+SkeletonASTVisitor::TraverseDecltypeTypeLoc(clang::DecltypeTypeLoc  /*loc*/)
 {
   return true;
 }
 
 bool
-SkeletonASTVisitor::TraverseCXXDeleteExpr(CXXDeleteExpr* expr, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseCXXDeleteExpr(CXXDeleteExpr* expr, DataRecursionQueue*  /*queue*/)
 {
   activeBinOpIdx_ = IndexResetter;
 
@@ -453,7 +453,7 @@ SkeletonASTVisitor::TraverseCXXDeleteExpr(CXXDeleteExpr* expr, DataRecursionQueu
 }
 
 bool
-SkeletonASTVisitor::TraverseInitListExpr(InitListExpr* expr, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseInitListExpr(InitListExpr* expr, DataRecursionQueue*  /*queue*/)
 {
   if (visitingGlobal_){
     QualType qty = expr->getType();
@@ -778,7 +778,7 @@ GlobalVariableVisitor::VisitDeclRefExpr(DeclRefExpr *expr)
 }
 
 bool
-GlobalVariableVisitor::VisitCallExpr(CallExpr* expr)
+GlobalVariableVisitor::VisitCallExpr(CallExpr*  /*expr*/)
 {
   //we have to assume this touches globals
   visitedGlobals_ = true;
@@ -857,7 +857,7 @@ SkeletonASTVisitor::visitPt2Pt(CallExpr *expr)
   }
 }
 bool 
-SkeletonASTVisitor::TraverseReturnStmt(clang::ReturnStmt* stmt, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseReturnStmt(clang::ReturnStmt* stmt, DataRecursionQueue*  /*queue*/)
 {
   try {
     PragmaActivateGuard pag(stmt, this);
@@ -872,7 +872,7 @@ SkeletonASTVisitor::TraverseReturnStmt(clang::ReturnStmt* stmt, DataRecursionQue
 }
 
 bool
-SkeletonASTVisitor::TraverseCXXMemberCallExpr(CXXMemberCallExpr* expr, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseCXXMemberCallExpr(CXXMemberCallExpr* expr, DataRecursionQueue*  /*queue*/)
 {
   PragmaActivateGuard pag(expr, this);
   if (pag.skipVisit()){
@@ -965,7 +965,7 @@ SkeletonASTVisitor::deleteNullVariableMember(NamedDecl* nullVarDecl, MemberExpr*
 }
 
 bool
-SkeletonASTVisitor::TraverseMemberExpr(MemberExpr *expr, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseMemberExpr(MemberExpr *expr, DataRecursionQueue*  /*queue*/)
 {
   ValueDecl* member = expr->getMemberDecl();
   if (isNullVariable(member)){
@@ -1008,7 +1008,7 @@ SkeletonASTVisitor::TraverseMemberExpr(MemberExpr *expr, DataRecursionQueue* que
 }
 
 bool
-SkeletonASTVisitor::TraverseCallExpr(CallExpr* expr, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseCallExpr(CallExpr* expr, DataRecursionQueue*  /*queue*/)
 {
   //this "breaks" connections for null variable propagation
   activeBinOpIdx_ = IndexResetter;
@@ -1825,7 +1825,7 @@ SkeletonASTVisitor::getVariableNameLocationEnd(VarDecl* D)
 
 bool
 SkeletonASTVisitor::TraverseUnresolvedLookupExpr(clang::UnresolvedLookupExpr* expr,
-                                                 DataRecursionQueue* queue)
+                                                 DataRecursionQueue*  /*queue*/)
 {
   for (auto iter=expr->decls_begin(); iter != expr->decls_end(); ++iter){
     NamedDecl* nd = *iter;
@@ -2369,7 +2369,7 @@ SkeletonASTVisitor::VisitCXXDependentScopeMemberExpr(clang::CXXDependentScopeMem
 }
 
 bool
-SkeletonASTVisitor::TraverseCompoundStmt(CompoundStmt* stmt, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseCompoundStmt(CompoundStmt* stmt, DataRecursionQueue*  /*queue*/)
 {
   try {
     PragmaActivateGuard pag(stmt, this);
@@ -2387,7 +2387,7 @@ SkeletonASTVisitor::TraverseCompoundStmt(CompoundStmt* stmt, DataRecursionQueue*
 }
 
 bool
-SkeletonASTVisitor::TraverseFieldDecl(clang::FieldDecl* fd, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseFieldDecl(clang::FieldDecl* fd, DataRecursionQueue*  /*queue*/)
 {
   try {
     PragmaActivateGuard pag(fd, this);
@@ -2403,7 +2403,7 @@ SkeletonASTVisitor::TraverseFieldDecl(clang::FieldDecl* fd, DataRecursionQueue* 
 }
 
 bool
-SkeletonASTVisitor::TraverseUnaryOperator(UnaryOperator* op, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseUnaryOperator(UnaryOperator* op, DataRecursionQueue*  /*queue*/)
 {
   switch(op->getOpcode()){
     case UO_Deref: {
@@ -2430,7 +2430,7 @@ SkeletonASTVisitor::TraverseCompoundAssignOperator(CompoundAssignOperator *op, D
 }
 
 bool
-SkeletonASTVisitor::TraverseBinaryOperator(BinaryOperator* op, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseBinaryOperator(BinaryOperator* op, DataRecursionQueue*  /*queue*/)
 {
   try {
 
@@ -2475,7 +2475,7 @@ SkeletonASTVisitor::TraverseBinaryOperator(BinaryOperator* op, DataRecursionQueu
 }
 
 bool
-SkeletonASTVisitor::TraverseIfStmt(IfStmt* stmt, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseIfStmt(IfStmt* stmt, DataRecursionQueue*  /*queue*/)
 {
   try {
     PragmaActivateGuard pag(stmt, this);
@@ -2498,7 +2498,7 @@ SkeletonASTVisitor::TraverseIfStmt(IfStmt* stmt, DataRecursionQueue* queue)
 }
 
 bool
-SkeletonASTVisitor::TraverseDeclStmt(DeclStmt* stmt, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseDeclStmt(DeclStmt* stmt, DataRecursionQueue*  /*queue*/)
 {
   try {
 
@@ -2531,7 +2531,7 @@ SkeletonASTVisitor::TraverseDeclStmt(DeclStmt* stmt, DataRecursionQueue* queue)
 }
 
 bool
-SkeletonASTVisitor::TraverseDoStmt(DoStmt* S, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseDoStmt(DoStmt* S, DataRecursionQueue*  /*queue*/)
 {
   try {
     PragmaActivateGuard pag(S, this);
@@ -2547,7 +2547,7 @@ SkeletonASTVisitor::TraverseDoStmt(DoStmt* S, DataRecursionQueue* queue)
 }
 
 bool
-SkeletonASTVisitor::TraverseWhileStmt(WhileStmt* S, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseWhileStmt(WhileStmt* S, DataRecursionQueue*  /*queue*/)
 {
   try {
     PragmaActivateGuard pag(S, this);
@@ -2563,7 +2563,7 @@ SkeletonASTVisitor::TraverseWhileStmt(WhileStmt* S, DataRecursionQueue* queue)
 }
 
 bool
-SkeletonASTVisitor::TraverseForStmt(ForStmt *S, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseForStmt(ForStmt *S, DataRecursionQueue*  /*queue*/)
 {
   try {
     PragmaActivateGuard pag(S, this);
@@ -2583,7 +2583,7 @@ SkeletonASTVisitor::TraverseForStmt(ForStmt *S, DataRecursionQueue* queue)
 }
 
 bool
-SkeletonASTVisitor::TraverseArraySubscriptExpr(ArraySubscriptExpr* expr, DataRecursionQueue* queue)
+SkeletonASTVisitor::TraverseArraySubscriptExpr(ArraySubscriptExpr* expr, DataRecursionQueue*  /*queue*/)
 {
   /**
   Expr* base = getUnderlyingExpr(expr->getBase());
@@ -2697,7 +2697,7 @@ SkeletonASTVisitor::propagateNullness(Decl* target, Decl* src)
 }
 
 void
-SkeletonASTVisitor::nullifyIfStmt(IfStmt* if_stmt, Decl* d)
+SkeletonASTVisitor::nullifyIfStmt(IfStmt* if_stmt, Decl*  /*d*/)
 {
   //oooooh, not good - I could really foobar things here
   //crash and burn and tell programmer to fix it

--- a/bin/clang/astVisitor.h
+++ b/bin/clang/astVisitor.h
@@ -1187,7 +1187,7 @@ struct PragmaActivateGuard {
 
 class GlobalVariableVisitor : public clang::RecursiveASTVisitor<GlobalVariableVisitor> {
  public:
-  GlobalVariableVisitor(clang::VarDecl* D, SkeletonASTVisitor* parent) :
+  GlobalVariableVisitor(clang::VarDecl*  /*D*/, SkeletonASTVisitor* parent) :
     visitedGlobals_(false),
     parent_(parent)
   {

--- a/bin/clang/astVisitorGlobalVars.cc
+++ b/bin/clang/astVisitorGlobalVars.cc
@@ -1,4 +1,5 @@
 #include "astVisitor.h"
+#include <unusedvariablemacro.h>
 
 using namespace clang;
 
@@ -544,9 +545,13 @@ SkeletonASTVisitor::checkInstanceStaticClassVar(VarDecl *D)
   //throw away the class name in the list of scopes
   sem.pop_back();
   auto semBegin = sem.begin();
-  for (auto& ignore : lex){ //figure out the overlap between lexical and semantic namespaces
-    ++semBegin;
-  }
+
+  std::advance(semBegin, lex.size());
+  // TODOWARNING @jjwilke look ^^, no loop needed
+  // for (auto& ignore : lex){ //figure out the overlap between lexical and semantic namespaces
+  //   ++semBegin;
+  // }
+  
   for (auto iter = semBegin; iter != sem.end(); ++iter){ //I must init/declare vars in the most enclosing namespace
     os << "namespace " << *iter << " {";
   }

--- a/bin/clang/computePragma.cc
+++ b/bin/clang/computePragma.cc
@@ -337,7 +337,7 @@ SSTImplicitStatePragma::doReplace(SourceLocation startInsert, SourceLocation fin
 }
 
 void
-SSTImplicitStatePragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTImplicitStatePragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
   doReplace(getStart(s), getEnd(s),
             false, true, r, values_);
@@ -402,7 +402,7 @@ SSTImplicitStatePragma::activate(Decl *d, Rewriter &r, PragmaConfig &cfg)
 }
 
 void
-SSTMemoryPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTMemoryPragma::activate(Stmt * /*s*/, Rewriter & /*r*/, PragmaConfig &cfg)
 {
   cfg.computeMemorySpec = memSpec_;
 }
@@ -414,7 +414,7 @@ enum OpenMPProperty {
 };
 
 std::string
-SSTOpenMPParallelPragma::numThreads(SourceLocation loc, CompilerInstance &CI, const std::list<Token> &tokens)
+SSTOpenMPParallelPragma::numThreads(SourceLocation  /*loc*/, CompilerInstance & /*CI*/, const std::list<Token> &tokens)
 {
   static const std::map<std::string, OpenMPProperty> omp_property_map = {
     {"num_threads", OMP_NTHREAD},

--- a/bin/clang/computePragma.h
+++ b/bin/clang/computePragma.h
@@ -120,7 +120,7 @@ class SSTMemoizeComputePragma : public SSTPragma
   SSTMemoizeComputePragma(clang::SourceLocation loc, clang::CompilerInstance& CI,
                           std::map<std::string, std::list<std::string>>&& in_args);
 
-  bool firstPass(const clang::Decl *d) const override {
+  bool firstPass(const clang::Decl * /*d*/) const override {
     return true;
   }
 
@@ -147,7 +147,7 @@ class SSTImplicitStatePragma : public SSTPragma
   SSTImplicitStatePragma(clang::SourceLocation loc, clang::CompilerInstance& CI,
       std::map<std::string, std::list<std::string>>&& in_args);
 
-  bool firstPass(const clang::Decl *d) const override {
+  bool firstPass(const clang::Decl * /*d*/) const override {
     return true;
   }
 

--- a/bin/clang/computeVisitor.cc
+++ b/bin/clang/computeVisitor.cc
@@ -63,12 +63,12 @@ struct GlobalVarReplacer
   }
 
   template <class T>
-  bool hasReplacement(T* t){
+  bool hasReplacement(T*  /*t*/){
     return false;
   }
 
   template <class T>
-  std::string getReplacement(T* t){
+  std::string getReplacement(T*  /*t*/){
     return "";
   }
 
@@ -88,7 +88,7 @@ ComputeVisitor::visitAccessDeclRefExpr(DeclRefExpr* expr, MemoryLocation& mloc)
 }
 
 void
-ComputeVisitor::visitAccessCompoundStmt(CompoundStmt* stmt, Loop::Body& body, MemoryLocation& mloc)
+ComputeVisitor::visitAccessCompoundStmt(CompoundStmt* stmt, Loop::Body&  /*body*/, MemoryLocation&  /*mloc*/)
 {
   errorAbort(stmt, CI, "visiting compound statement in data flow analysis");
 }
@@ -354,7 +354,7 @@ ComputeVisitor::visitBodyArraySubscriptExpr(ArraySubscriptExpr* expr, Loop::Body
 
 
 void
-ComputeVisitor::visitBodyDeclRefExpr(DeclRefExpr* expr, Loop::Body& body, bool isLHS)
+ComputeVisitor::visitBodyDeclRefExpr(DeclRefExpr* expr, Loop::Body&  /*body*/, bool isLHS)
 {
   NamedDecl* decl = expr->getFoundDecl();
   Variable& var = getVariable(decl);

--- a/bin/clang/computeVisitor.h
+++ b/bin/clang/computeVisitor.h
@@ -53,7 +53,7 @@ Questions? Contact sst-macro-help@sandia.gov
 class ComputeVisitor  {
  public:
   //97 = 'a', for debug printing
-  ComputeVisitor(clang::CompilerInstance& c, SSTPragmaList& plist, ComputeVisitor* par,
+  ComputeVisitor(clang::CompilerInstance& c, SSTPragmaList& plist, ComputeVisitor*  /*par*/,
                  SkeletonASTVisitor* ctxt) :
     idCount(97), 
     currentGeneration(1), 

--- a/bin/clang/frontendActions.cc
+++ b/bin/clang/frontendActions.cc
@@ -163,14 +163,14 @@ ReplaceAction::ExecuteAction()
 
 struct PragmaPPCallback : public PPCallbacks {
 
-  void PragmaDirective(SourceLocation Loc, PragmaIntroducerKind Introducer) override {
+  void PragmaDirective(SourceLocation Loc, PragmaIntroducerKind  /*Introducer*/) override {
     SSTPragmaHandler::pragmaDirectiveLoc = Loc;
   }
 
 };
 
 void
-ReplaceAction::initPragmas(CompilerInstance& CI, pragmas::Mode m)
+ReplaceAction::initPragmas(CompilerInstance& CI, pragmas::Mode  /*m*/)
 {
   /** Need this to figure out begin location of #pragma */
   CI.getPreprocessor().addPPCallbacks(llvm::make_unique<PragmaPPCallback>());

--- a/bin/clang/frontendActions.cc
+++ b/bin/clang/frontendActions.cc
@@ -100,9 +100,9 @@ ReplaceAction::ExecuteAction()
 {
   if (!ci_->hasSema()) ci_->createSema(getTranslationUnitKind(), nullptr);
 
-  TranslationUnitKind TUKind = TU_Complete;
+  // TODOWARNING TranslationUnitKind TUKind = TU_Complete;
   ASTContext& Ctx = ci_->getASTContext();
-  CodeCompleteConsumer* CompletionConsumer = nullptr;
+  // TODOWARNING CodeCompleteConsumer* CompletionConsumer = nullptr;
   ASTConsumer& Consumer = ci_->getASTConsumer();
   Sema& S = ci_->getSema();
 

--- a/bin/clang/pragmas.cc
+++ b/bin/clang/pragmas.cc
@@ -275,6 +275,7 @@ std::map<std::string, std::list<std::string>>
 SSTPragma::getMap(SourceLocation loc, CompilerInstance& CI, const std::list<clang::Token>& tokens)
 {
   std::map<std::string, std::list<std::string>> allArgs;
+#if 0 // TODOWARNING
   auto iter = tokens.begin();
   auto incrementIter = [&](){
     ++iter;
@@ -283,6 +284,7 @@ SSTPragma::getMap(SourceLocation loc, CompilerInstance& CI, const std::list<clan
        "mis-formatted pragma, pragma modifiers should be of the form 'arg(a)' or 'arg(a,b)'");
     }
   };
+#endif
 
 
   int parenDepth = 0;

--- a/bin/clang/pragmas.cc
+++ b/bin/clang/pragmas.cc
@@ -169,7 +169,7 @@ int SSTPragma::getActiveMode() const {
 
 void
 SSTPragmaNamespace::addFactory(int modeMask, const std::string &name,
-                               bool deleteOnUse, PragmaHandlerFactoryBase *factory)
+                               bool  /*deleteOnUse*/, PragmaHandlerFactoryBase *factory)
 {
   for (int i=0; i < NUM_MODES; ++i){
     int testMask = 1 << i;
@@ -220,7 +220,7 @@ PragmaRegisterMap::getNamespace(const std::string &ns)
 }
 
 void
-SSTPragmaHandler::configure(bool delOnUse, Token& PragmaTok, Preprocessor& PP, SSTPragma* fsp)
+SSTPragmaHandler::configure(bool delOnUse, Token&  /*PragmaTok*/, Preprocessor& PP, SSTPragma* fsp)
 {
   static int pragmaDepth = 0;
   static int maxPragmaDepth = 0;
@@ -253,7 +253,7 @@ SSTPragmaHandler::configure(bool delOnUse, Token& PragmaTok, Preprocessor& PP, S
 }
 
 void
-SSTPragmaHandler::HandlePragma(Preprocessor &PP, PragmaIntroducerKind Introducer, Token& PragmaTok)
+SSTPragmaHandler::HandlePragma(Preprocessor &PP, PragmaIntroducerKind  /*Introducer*/, Token& PragmaTok)
 {
   std::list<Token> tokens;
   Token next; PP.Lex(next);
@@ -272,7 +272,7 @@ SSTPragmaHandler::HandlePragma(Preprocessor &PP, PragmaIntroducerKind Introducer
 }
 
 std::map<std::string, std::list<std::string>>
-SSTPragma::getMap(SourceLocation loc, CompilerInstance& CI, const std::list<clang::Token>& tokens)
+SSTPragma::getMap(SourceLocation  /*loc*/, CompilerInstance& CI, const std::list<clang::Token>& tokens)
 {
   std::map<std::string, std::list<std::string>> allArgs;
 #if 0 // TODOWARNING
@@ -339,7 +339,7 @@ SSTPragma::getSingleString(const std::list<Token>& tokens, clang::CompilerInstan
 }
 
 void
-SSTDeletePragma::activate(clang::Stmt* s, clang::Rewriter& r, PragmaConfig& cfg){
+SSTDeletePragma::activate(clang::Stmt* s, clang::Rewriter& r, PragmaConfig&  /*cfg*/){
   replace(s,r,"",*CI);
   switch(s->getStmtClass()){
   case Stmt::ForStmtClass:
@@ -352,13 +352,13 @@ SSTDeletePragma::activate(clang::Stmt* s, clang::Rewriter& r, PragmaConfig& cfg)
 }
 
 void
-SSTDeletePragma::activate(clang::Decl* d, clang::Rewriter& r, PragmaConfig& cfg){
+SSTDeletePragma::activate(clang::Decl* d, clang::Rewriter& r, PragmaConfig&  /*cfg*/){
   replace(d,r,"",*CI);
   throw DeclDeleteException(d);
 }
 
 void
-SSTEmptyPragma::activate(clang::Decl* d, clang::Rewriter& r, PragmaConfig& cfg){
+SSTEmptyPragma::activate(clang::Decl* d, clang::Rewriter& r, PragmaConfig&  /*cfg*/){
   std::stringstream sstr;
   sstr << "{" << body_;
   if (body_.size()) sstr << ";";
@@ -375,25 +375,25 @@ SSTEmptyPragma::activate(clang::Decl* d, clang::Rewriter& r, PragmaConfig& cfg){
 }
 
 void
-SSTEmptyPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTEmptyPragma::activate(Stmt *s, Rewriter & /*r*/, PragmaConfig & /*cfg*/)
 {
   errorAbort(s, *CI, "pragma empty should only apply to declarations, not statmements");
 }
 
 void
-SSTKeepPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTKeepPragma::activate(Stmt * /*s*/, Rewriter & /*r*/, PragmaConfig &cfg)
 {
   cfg.makeNoChanges = true;
 }
 
 void
-SSTKeepPragma::activate(Decl *d, Rewriter &r, PragmaConfig &cfg)
+SSTKeepPragma::activate(Decl * /*d*/, Rewriter & /*r*/, PragmaConfig &cfg)
 {
   cfg.makeNoChanges = true;
 }
 
 void
-SSTNewPragma::activate(Decl *d, Rewriter &r, PragmaConfig &cfg)
+SSTNewPragma::activate(Decl *d, Rewriter & /*r*/, PragmaConfig & /*cfg*/)
 {
 #define dcase(type,d,rw) \
   case(clang::Decl::type): \
@@ -445,7 +445,7 @@ SSTNewPragma::visitBinaryOperator(BinaryOperator *op, Rewriter& r)
 }
 
 void
-SSTNewPragma::activate(Stmt* stmt, Rewriter &r, PragmaConfig& cfg)
+SSTNewPragma::activate(Stmt* stmt, Rewriter &r, PragmaConfig&  /*cfg*/)
 {
 #define scase(type,s,rw) \
   case(clang::Stmt::type##Class): \
@@ -461,7 +461,7 @@ SSTNewPragma::activate(Stmt* stmt, Rewriter &r, PragmaConfig& cfg)
 }
 
 void
-SSTKeepIfPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTKeepIfPragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
   PrettyPrinter pp;
   pp.os << "if (" << ifCond_ << "){ ";
@@ -471,7 +471,7 @@ SSTKeepIfPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
 }
 
 void
-SSTBranchPredictPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTBranchPredictPragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
   if (s->getStmtClass() != Stmt::IfStmtClass){
     errorAbort(s, *CI, "predicate pragma not applied to if statement");
@@ -492,7 +492,7 @@ SSTOverheadPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
 }
 
 void
-SSTAdvanceTimePragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTAdvanceTimePragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
   PrettyPrinter pp;
   std::string replacement;
@@ -516,7 +516,7 @@ SSTAdvanceTimePragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
 }
 
 void
-SSTCallFunctionPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTCallFunctionPragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
   r.InsertText(getStart(s), repl_, false);
 }
@@ -551,7 +551,7 @@ SSTMallocPragma::visitDeclStmt(DeclStmt *stmt, Rewriter &r)
 }
 
 void
-SSTMallocPragma::activate(Stmt *stmt, Rewriter &r, PragmaConfig& cfg)
+SSTMallocPragma::activate(Stmt *stmt, Rewriter &r, PragmaConfig&  /*cfg*/)
 {
 #define scase(type,s,rw) \
   case(clang::Stmt::type##Class): \
@@ -567,7 +567,7 @@ SSTMallocPragma::activate(Stmt *stmt, Rewriter &r, PragmaConfig& cfg)
 }
 
 void
-SSTReturnPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTReturnPragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
   if (s->getStmtClass() != Stmt::ReturnStmtClass){
     errorAbort(s, *CI,
@@ -578,7 +578,7 @@ SSTReturnPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
 }
 
 void
-SSTReturnPragma::activate(Decl* d, Rewriter& r, PragmaConfig& cfg)
+SSTReturnPragma::activate(Decl* d, Rewriter& r, PragmaConfig&  /*cfg*/)
 {
   if (d->getKind() != Decl::Function){
     errorAbort(d, *CI, "pragma return not applied to function definition");
@@ -593,18 +593,18 @@ SSTReturnPragma::activate(Decl* d, Rewriter& r, PragmaConfig& cfg)
 }
 
 void
-SSTGlobalVariablePragma::activate(Stmt* s, Rewriter& r, PragmaConfig& cfg)
+SSTGlobalVariablePragma::activate(Stmt*  /*s*/, Rewriter&  /*r*/, PragmaConfig& cfg)
 {
   cfg.dependentScopeGlobal = name_;
 }
 
 void
-SSTGlobalVariablePragma::activate(Decl *d, Rewriter &r, PragmaConfig &cfg)
+SSTGlobalVariablePragma::activate(Decl *d, Rewriter & /*r*/, PragmaConfig & /*cfg*/)
 {
   errorAbort(d, *CI, "global pragma should only be applied to statements");
 }
 
-SSTNullVariablePragma::SSTNullVariablePragma(SourceLocation loc, CompilerInstance& CI,
+SSTNullVariablePragma::SSTNullVariablePragma(SourceLocation  /*loc*/, CompilerInstance& CI,
                                              const std::list<Token> &tokens)
  : declAppliedTo_(nullptr),
    transitiveFrom_(nullptr),
@@ -685,7 +685,7 @@ static NamedDecl* getNamedDecl(Decl* d)
 }
 
 void
-SSTNullVariablePragma::doActivate(Decl* d, Rewriter& r, PragmaConfig& cfg)
+SSTNullVariablePragma::doActivate(Decl* d, Rewriter&  /*r*/, PragmaConfig& cfg)
 {
   if (!extras_.empty()){
     errorAbort(d, *CI, "illegal null_variable spec: "
@@ -837,13 +837,13 @@ SSTNullFieldsPragma::SSTNullFieldsPragma(SourceLocation loc, CompilerInstance &C
 }
 
 void
-SSTNullFieldsPragma::activate(Decl *d, Rewriter &r, PragmaConfig &cfg)
+SSTNullFieldsPragma::activate(Decl *d, Rewriter & /*r*/, PragmaConfig &cfg)
 {
   doActivateFieldsPragma(d, cfg, false, nullFields_, this, *CI);
 }
 
 void
-SSTNullFieldsPragma::activate(Stmt *stmt, Rewriter &r, PragmaConfig &cfg)
+SSTNullFieldsPragma::activate(Stmt *stmt, Rewriter & /*r*/, PragmaConfig & /*cfg*/)
 {
   errorAbort(stmt, *CI,
       "null_fields pragma should only be applied to struct declarations, not statements");
@@ -860,19 +860,19 @@ SSTNonnullFieldsPragma::SSTNonnullFieldsPragma(SourceLocation loc, CompilerInsta
 }
 
 void
-SSTNonnullFieldsPragma::activate(Decl *d, Rewriter &r, PragmaConfig &cfg)
+SSTNonnullFieldsPragma::activate(Decl *d, Rewriter & /*r*/, PragmaConfig &cfg)
 {
   doActivateFieldsPragma(d, cfg, true, nonnullFields_, this, *CI);
 }
 
 void
-SSTNonnullFieldsPragma::activate(Stmt *stmt, Rewriter &r, PragmaConfig &cfg)
+SSTNonnullFieldsPragma::activate(Stmt *stmt, Rewriter & /*r*/, PragmaConfig & /*cfg*/)
 {
   errorAbort(stmt, *CI,
      "nonull_fields pragma should only be applied to struct declarations, not statements");
 }
 
-SSTNullTypePragma::SSTNullTypePragma(SourceLocation loc, CompilerInstance& CI,
+SSTNullTypePragma::SSTNullTypePragma(SourceLocation  /*loc*/, CompilerInstance& CI,
                                      const std::list<Token> &tokens)
 {
   //this is valid - it just means wipe out the type
@@ -1005,7 +1005,7 @@ SSTAdvanceTimePragma::SSTAdvanceTimePragma(SourceLocation loc, CompilerInstance&
   amount_ = sval.str();
 }
 
-SSTCallFunctionPragma::SSTCallFunctionPragma(SourceLocation loc, CompilerInstance& CI,
+SSTCallFunctionPragma::SSTCallFunctionPragma(SourceLocation  /*loc*/, CompilerInstance& CI,
                                              const std::list<Token> &tokens)
 {
   std::stringstream sstr;
@@ -1047,7 +1047,7 @@ SSTStackAllocPragma::SSTStackAllocPragma(SourceLocation loc, CompilerInstance& C
 }
 
 void
-SSTStackAllocPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTStackAllocPragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
   if (toFree_.size()){
     std::string repl = "sstmac_free_stack(" + toFree_ + ")";

--- a/bin/clang/pragmas.h
+++ b/bin/clang/pragmas.h
@@ -150,11 +150,11 @@ struct SSTPragma {
    * @param d tag parameter, whether declarations should be visited first pass
    * @return
    */
-  virtual bool firstPass(const clang::Decl* d) const {
+  virtual bool firstPass(const clang::Decl*  /*d*/) const {
     return false;
   }
 
-  virtual bool firstPass(const clang::Stmt* s) const {
+  virtual bool firstPass(const clang::Stmt*  /*s*/) const {
     return false;
   }
 
@@ -353,8 +353,8 @@ class SSTPragmaHandlerInstance : public SSTPragmaHandler
 
 template <class T> struct SSTNoArgsPragmaShim : public T
 {
-  SSTNoArgsPragmaShim(clang::SourceLocation loc, clang::CompilerInstance& CI,
-                  const std::list<clang::Token>& tokens) :
+  SSTNoArgsPragmaShim(clang::SourceLocation  /*loc*/, clang::CompilerInstance&  /*CI*/,
+                  const std::list<clang::Token>&  /*tokens*/) :
     T() {
       this->classId = pragmaID<T>();
     }
@@ -363,7 +363,7 @@ template <class T> struct SSTNoArgsPragmaShim : public T
 template <class T> struct SSTStringPragmaShim : public T
 {
   using T::getSingleString;
-  SSTStringPragmaShim(clang::SourceLocation loc, clang::CompilerInstance& CI,
+  SSTStringPragmaShim(clang::SourceLocation  /*loc*/, clang::CompilerInstance& CI,
                   const std::list<clang::Token>& tokens) :
     T(getSingleString(tokens,CI)) //just a single string gets passed up
   {
@@ -554,7 +554,7 @@ class SSTNullVariablePragma : public SSTPragma {
     return ret;
   }
 
-  bool firstPass(const clang::Decl* d) const override {
+  bool firstPass(const clang::Decl*  /*d*/) const override {
     return true;
   }
 
@@ -654,14 +654,14 @@ class SSTNullVariableStopPragma : public SSTPragma {
  public:
   SSTNullVariableStopPragma(){}
 
-  void activate(clang::Stmt* s, clang::Rewriter& r, PragmaConfig& cfg) override {
+  void activate(clang::Stmt*  /*s*/, clang::Rewriter&  /*r*/, PragmaConfig& cfg) override {
     cfg.nullifyDeclarationsPragma = nullptr;
   }
 };
 
 class SSTNullVariableGeneratorPragma : public SSTPragma {
  public:
-  SSTNullVariableGeneratorPragma(clang::SourceLocation loc, clang::CompilerInstance& CI,
+  SSTNullVariableGeneratorPragma(clang::SourceLocation  /*loc*/, clang::CompilerInstance&  /*CI*/,
                         const std::list<clang::Token>& tokens) :
     tokens_(tokens)
   {
@@ -671,7 +671,7 @@ class SSTNullVariableGeneratorPragma : public SSTPragma {
     return new SSTNullVariablePragma(getStart(d), CI, tokens_);
   }
 
-  void activate(clang::Stmt* s, clang::Rewriter& r, PragmaConfig& cfg) override {
+  void activate(clang::Stmt*  /*s*/, clang::Rewriter&  /*r*/, PragmaConfig& cfg) override {
     cfg.nullifyDeclarationsPragma = this;
   }
 
@@ -824,7 +824,7 @@ class SSTNonnullFieldsPragma : public SSTNullVariablePragma {
  private:
   void activate(clang::Stmt *stmt, clang::Rewriter &r, PragmaConfig& cfg) override;
   void activate(clang::Decl* d, clang::Rewriter &r, PragmaConfig& cfg) override;
-  bool firstPass(const clang::Decl* d) const override { return false; }
+  bool firstPass(const clang::Decl*  /*d*/) const override { return false; }
   std::set<std::string> nonnullFields_;
 
 };
@@ -835,7 +835,7 @@ class SSTNullFieldsPragma : public SSTNullVariablePragma {
                       const std::list<clang::Token>& tokens);
 
  private:
-  bool firstPass(const clang::Decl* d) const override { return false; }
+  bool firstPass(const clang::Decl*  /*d*/) const override { return false; }
   void activate(clang::Stmt *stmt, clang::Rewriter &r, PragmaConfig& cfg) override;
   void activate(clang::Decl* d, clang::Rewriter &r, PragmaConfig& cfg) override;
 

--- a/bin/clang/printAll.h
+++ b/bin/clang/printAll.h
@@ -173,7 +173,7 @@ struct PrintAll {
     os << expr->getMemberDecl()->getNameAsString();
   }
 
-  void recurseDeclRefExpr(const DeclRefExpr* expr, std::ostream& os, Replacer&& repl){
+  void recurseDeclRefExpr(const DeclRefExpr* expr, std::ostream& os, Replacer&&  /*repl*/){
     PrettyPrinter pp;
     pp.print(expr);
     os << pp.str();
@@ -197,10 +197,10 @@ struct PrintAll {
 struct NullReplacement
 {
   template <class T>
-  bool hasReplacement(T* t){ return false; }
+  bool hasReplacement(T*  /*t*/){ return false; }
 
   template <class T>
-  std::string getReplacement(T* t){ return ""; }
+  std::string getReplacement(T*  /*t*/){ return ""; }
 };
 
 #include <sstream>

--- a/bin/clang/recurseAll.h
+++ b/bin/clang/recurseAll.h
@@ -115,32 +115,32 @@ struct RecurseAll {
 #undef recurse_case
   }
 
-  void recurseReturnStmt(const ReturnStmt* stmt, ExprRole role, Args&& ...args){
+  void recurseReturnStmt(const ReturnStmt* stmt, ExprRole  /*role*/, Args&& ...args){
     recurse(stmt->getRetValue(), ExprRole::ReturnValue, std::forward<Args>(args)...);
   }
 
-  void recurseForStmt(const ForStmt* stmt, ExprRole role, Args&& ...args){
+  void recurseForStmt(const ForStmt* stmt, ExprRole  /*role*/, Args&& ...args){
     recurse(stmt->getInit(), ExprRole::ForInit, std::forward<Args>(args)...);
     recurse(stmt->getCond(), ExprRole::ForCond, std::forward<Args>(args)...);
     recurse(stmt->getInc(), ExprRole::ForInc, std::forward<Args>(args)...);
     recurse(stmt->getBody(), ExprRole::ForBody, std::forward<Args>(args)...);
   }
 
-  void recurseCompoundStmt(const CompoundStmt* stmt, ExprRole role, Args&& ...args){
+  void recurseCompoundStmt(const CompoundStmt* stmt, ExprRole  /*role*/, Args&& ...args){
     auto end = stmt->child_end();
     for (auto iter=stmt->child_begin(); iter != end; ++iter){
       recurse(*iter, ExprRole::Standalone, std::forward<Args>(args)...);
     }
   }
 
-  void recurseIfStmt(const IfStmt* stmt, ExprRole role, Args&& ...args){
+  void recurseIfStmt(const IfStmt* stmt, ExprRole  /*role*/, Args&& ...args){
     recurse(stmt->getCond(), ExprRole::IfCond, std::forward<Args>(args)...);
     recurse(stmt->getThen(), ExprRole::IfBody, std::forward<Args>(args)...);
     if (stmt->getElse()) recurse(stmt->getElse(), ExprRole::IfElse, std::forward<Args>(args)...);
     if (stmt->getInit()) recurse(stmt->getInit(), ExprRole::IfInit, std::forward<Args>(args)...);
   }
 
-  void recurseDeclStmt(const DeclStmt* stmt, ExprRole role, Args&& ...args){
+  void recurseDeclStmt(const DeclStmt* stmt, ExprRole  /*role*/, Args&& ...args){
     const Decl* D = stmt->getSingleDecl();
     if (D){
       switch(D->getKind()){
@@ -158,7 +158,7 @@ struct RecurseAll {
     }
   }
 
-  void recurseBinaryOperator(const BinaryOperator* op, ExprRole role, Args&& ...args){
+  void recurseBinaryOperator(const BinaryOperator* op, ExprRole  /*role*/, Args&& ...args){
     recurse(op->getLHS(), ExprRole::BinOpLHS, std::forward<Args>(args)...);
     recurse(op->getRHS(), ExprRole::BinOpRHS, std::forward<Args>(args)...);
   }
@@ -168,7 +168,7 @@ struct RecurseAll {
     recurse(expr->getSubExpr(), role, std::forward<Args>(args)...);
   }
 
-  void recurseCallExpr(const CallExpr* expr, ExprRole role, Args&& ...args){
+  void recurseCallExpr(const CallExpr* expr, ExprRole  /*role*/, Args&& ...args){
     recurse(expr->getCallee(), ExprRole::CallFxn, std::forward<Args>(args)...);
     for (int i=0; i < expr->getNumArgs(); ++i){
       recurse(expr->getArg(i), ExprRole::CallArg, std::forward<Args>(args)...);
@@ -179,7 +179,7 @@ struct RecurseAll {
     recurse(expr->getSubExpr(), role, std::forward<Args>(args)...);
   }
 
-  void recurseCXXMemberCallExpr(const CXXMemberCallExpr* expr, ExprRole role, Args&& ...args){
+  void recurseCXXMemberCallExpr(const CXXMemberCallExpr* expr, ExprRole  /*role*/, Args&& ...args){
     //recurse(expr->getImplicitObjectArgument(), ExprRole::ThisPtr, std::forward<Args>(args)...);
     recurse(expr->getCallee(), ExprRole::CallFxn, std::forward<Args>(args)...);
     for (int i=0; i < expr->getNumArgs(); ++i){
@@ -187,7 +187,7 @@ struct RecurseAll {
     }
   }
 
-  void recurseCXXOperatorCallExpr(const CXXOperatorCallExpr* expr, ExprRole role, Args&& ...args){
+  void recurseCXXOperatorCallExpr(const CXXOperatorCallExpr* expr, ExprRole  /*role*/, Args&& ...args){
     //recurse(expr->getImplicitObjectArgument(), ExprRole::ThisPtr, std::forward<Args>(args)...);
     recurse(expr->getCallee(), ExprRole::CallFxn, std::forward<Args>(args)...);
     for (int i=0; i < expr->getNumArgs(); ++i){
@@ -196,7 +196,7 @@ struct RecurseAll {
   }
 
 
-  void recurseMemberExpr(const MemberExpr* expr, ExprRole role, Args&& ...args){
+  void recurseMemberExpr(const MemberExpr* expr, ExprRole  /*role*/, Args&& ...args){
     recurse(expr->getBase(), ExprRole::ThisPtr, std::forward<Args>(args)...);
   }
 
@@ -214,7 +214,7 @@ struct RecurseAll {
     recurse(expr->getSubExpr(), role, std::forward<Args>(args)...);
   }
 
-  void recurseArraySubscriptExpr(const ArraySubscriptExpr* expr, ExprRole role, Args&& ...args){
+  void recurseArraySubscriptExpr(const ArraySubscriptExpr* expr, ExprRole  /*role*/, Args&& ...args){
     recurse(expr->getBase(), ExprRole::ArrayBase, std::forward<Args>(args)...);
     recurse(expr->getIdx(), ExprRole::ArrayIdx, std::forward<Args>(args)...);
   }
@@ -225,7 +225,7 @@ struct RecurseAll {
 struct NullVisit
 {
   template <class T, class... Args>
-  bool operator()(T* t, ExprRole role, Args&& ...args){ return false; }
+  bool operator()(T*  /*t*/, ExprRole  /*role*/, Args&& ... /*args*/){ return false; }
 };
 
 template <class PreVisit, class PostVisit, class... Args>

--- a/bin/clang/replacePragma.cc
+++ b/bin/clang/replacePragma.cc
@@ -82,14 +82,14 @@ struct ReplacementConfig
 template <bool PreVisit> //whether pre or post visit
 struct ReplaceStatementVisit {
   template <class T, class... Args>
-  bool operator()(T* t, ExprRole role,
-                  CompilerInstance& CI,
-                  ReplacementConfig& cfg) {
+  bool operator()(T*  /*t*/, ExprRole  /*role*/,
+                  CompilerInstance&  /*CI*/,
+                  ReplacementConfig&  /*cfg*/) {
     return false;
   }
 
   void visit(const Expr* expr, const std::string& name, ExprRole role,
-             CompilerInstance& CI, ReplacementConfig& cfg){
+             CompilerInstance&  /*CI*/, ReplacementConfig& cfg){
     if (PreVisit && name == cfg.matchText){
       switch (role){
         case ExprRole::ArrayBase:
@@ -105,7 +105,7 @@ struct ReplaceStatementVisit {
   }
 
   void visit(const Expr* expr, ExprRole role,
-             CompilerInstance& CI,
+             CompilerInstance&  /*CI*/,
              ReplacementConfig& cfg)
   {
     switch(role){
@@ -157,7 +157,7 @@ struct ReplaceStatementVisit {
     return false;
   }
 
-  bool operator()(const DeclStmt* stmt, ExprRole role,
+  bool operator()(const DeclStmt* stmt, ExprRole  /*role*/,
                   CompilerInstance& CI, ReplacementConfig& cfg){
     if (PreVisit){
       const Decl* d = stmt->getSingleDecl();
@@ -221,7 +221,7 @@ SSTReplacePragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
 
 
 void
-SSTReplacePragma::activate(Decl *d, Rewriter &r, PragmaConfig &cfg)
+SSTReplacePragma::activate(Decl *d, Rewriter &r, PragmaConfig & /*cfg*/)
 {
 #define repl_case(kind,d,rw) \
   case Decl::kind: activate##kind##Decl(cast<kind##Decl>(d), rw); break
@@ -254,7 +254,7 @@ SSTReplacePragma::activateCXXRecordDecl(CXXRecordDecl *d, Rewriter &r)
 }
 
 void
-SSTInitPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTInitPragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
 #define repl_case(cls,s,rw) \
   case Stmt::cls##Class: activate##cls(cast<cls>(s), rw); break
@@ -276,7 +276,7 @@ SSTInitPragma::activateBinaryOperator(BinaryOperator* op, Rewriter& r)
 }
 
 void
-SSTInsteadPragma::activate(Stmt *s, Rewriter &r, PragmaConfig &cfg)
+SSTInsteadPragma::activate(Stmt *s, Rewriter &r, PragmaConfig & /*cfg*/)
 {
   replace(s, r, repl_, *CI);
   throw StmtDeleteException(s);

--- a/bin/clang/replacePragma.h
+++ b/bin/clang/replacePragma.h
@@ -83,7 +83,7 @@ class SSTStartReplacePragma : public SSTReplacePragma {
                         const std::list<clang::Token>& tokens) :
     SSTReplacePragma(loc,CI,tokens){}
 
-  void activate(clang::Stmt* s, clang::Rewriter& r, PragmaConfig& cfg) override {
+  void activate(clang::Stmt*  /*s*/, clang::Rewriter&  /*r*/, PragmaConfig& cfg) override {
     cfg.replacePragmas[fxn_] = this;
   }
 };
@@ -93,7 +93,7 @@ class SSTStopReplacePragma : public SSTPragma {
   SSTStopReplacePragma(const std::string& fxn) :
     fxn_(fxn){}
 
-  void activate(clang::Stmt* s, clang::Rewriter& r, PragmaConfig& cfg) override {
+  void activate(clang::Stmt*  /*s*/, clang::Rewriter&  /*r*/, PragmaConfig& cfg) override {
     cfg.replacePragmas.erase(fxn_);
   }
  private:

--- a/bin/clang/util.cc
+++ b/bin/clang/util.cc
@@ -124,7 +124,7 @@ internalError(const std::string &error){
 
 
 void
-internalError(SourceLocation loc, CompilerInstance &CI, const std::string &error)
+internalError(SourceLocation  /*loc*/, CompilerInstance & /*CI*/, const std::string &error)
 {
   std::string newError = "internal error: " + error;
 	 

--- a/bin/clang/validateScope.h
+++ b/bin/clang/validateScope.h
@@ -71,23 +71,23 @@ struct VariableScope {
 
 struct ValidateScope {
   bool operator()(const clang::Expr* e, 
-                  ExprRole role, Replacements& repls,
-                  clang::CompilerInstance& CI, 
-                  VariableScope& scope){
+                  ExprRole  /*role*/, Replacements& repls,
+                  clang::CompilerInstance&  /*CI*/, 
+                  VariableScope&  /*scope*/){
     //if this has been replaced, stop recursing
     return repls.exprs.find(e) != repls.exprs.end();
   }
 
-  bool operator()(const clang::Stmt* s, 
-                  ExprRole role, Replacements& repls,
-                  clang::CompilerInstance& CI, 
-                  VariableScope& scope){
+  bool operator()(const clang::Stmt*  /*s*/, 
+                  ExprRole  /*role*/, Replacements&  /*repls*/,
+                  clang::CompilerInstance&  /*CI*/, 
+                  VariableScope&  /*scope*/){
     //do nothing
     return false; //but don't stop recursing
   }
 
   bool operator()(const clang::DeclRefExpr* expr, 
-                  ExprRole role, Replacements& repls,
+                  ExprRole  /*role*/, Replacements& repls,
                   clang::CompilerInstance& CI, 
                   VariableScope& scope){
     const clang::ValueDecl* d = expr->getDecl();

--- a/bin/sstccvars.py.in
+++ b/bin/sstccvars.py.in
@@ -16,6 +16,7 @@ sstCppFlags = [
 "@CPPFLAGS@",
 "-I${includedir}/sstmac",
 "-I${includedir}",
+"-I${includedir}/include",
 "-I${includedir}/memoization",
 "-I${includedir}/sstmac/software/libraries",
 "-I${includedir}/sstmac/tools",

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -10,4 +10,6 @@
 #
 
 library_includedir=$(includedir)
-nobase_library_include_HEADERS = clangtidymacros.h
+nobase_library_include_HEADERS = \
+																 clangtidymacros.h \
+																 unusedvariablemacro.h

--- a/include/unusedvariablemacro.h
+++ b/include/unusedvariablemacro.h
@@ -42,45 +42,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Questions? Contact sst-macro-help@sandia.gov
 */
 
-#include <sstmac/hardware/common/packet.h>
-#include <sstmac/hardware/common/unique_id.h>
-#include <sstmac/hardware/common/flow.h>
-#include <sprockit/serializer.h>
+#ifndef include_unusedvariablemacro_h
+#define include_unusedvariablemacro_h
 
-namespace sstmac {
-namespace hw {
+#if __cplusplus >= 201703L
+  #define SSTMAC_MAYBE_UNUSED [[maybe_unused]]
+#else
+  #define SSTMAC_MAYBE_UNUSED __attribute__((unused))
+#endif
 
-Packet::Packet(
-  Flow* flow,
-  uint32_t num_bytes,
-  uint64_t flow_id,
-  bool is_tail,
-  NodeId fromaddr,
-  NodeId toaddr) :
- toaddr_(toaddr),
- fromaddr_(fromaddr),
- flow_id_(flow_id),
- num_bytes_(num_bytes),
- payload_(flow)
-{
-  ::memset(rtr_metadata_, 0, sizeof(rtr_metadata_));
-  ::memset(stats_metadata_, 0, sizeof(stats_metadata_));
-  ::memset(nic_metadata_, 0, sizeof(nic_metadata_));
-  auto hdr = rtrHeader<Header>();
-  hdr->is_tail = is_tail;
-}
-
-void
-Packet::serialize_order(serializer& ser)
-{
-  Event::serialize_order(ser);
-  ser & payload_;
-  ser & num_bytes_;
-  ser & flow_id_;
-  ser & rtr_metadata_;
-  ser & stats_metadata_;
-  ser & nic_metadata_;
-}
-
-}
-}
+#endif // include_unusedvariablemacro_h

--- a/sprockit/sprockit/factory.h
+++ b/sprockit/sprockit/factory.h
@@ -218,7 +218,7 @@ template <> class NoValidConstructorsForDerivedType<0> {};
 template <class Base> struct CtorList<Base,void>
 {
   template <class T,int numValidCtors>
-  static bool add(const std::string& lib, const std::string& elem){
+  static bool add(const std::string&  /*lib*/, const std::string&  /*elem*/){
     return NoValidConstructorsForDerivedType<numValidCtors>::atLeastOneValidCtor;
   }
 };

--- a/sprockit/sprockit/keyword_registration.cc
+++ b/sprockit/sprockit/keyword_registration.cc
@@ -73,7 +73,7 @@ KeywordRegistration::deleteStatics()
 }
 
 bool
-KeywordRegistration::isValidNamespace(const std::string& ns)
+KeywordRegistration::isValidNamespace(const std::string&  /*ns*/)
 {
   return true;
 }

--- a/sprockit/sprockit/serialize.h
+++ b/sprockit/sprockit/serialize.h
@@ -108,7 +108,7 @@ template <class T,bool flag>
 class serialize_ptr
 {
  public:
-  void operator()(serializer& ser, T*& t){
+  void operator()(serializer&  /*ser*/, T*&  /*t*/){
     ::abort();
   }
 };

--- a/sprockit/sprockit/serialize_sizer.h
+++ b/sprockit/sprockit/serialize_sizer.h
@@ -57,7 +57,7 @@ class ser_sizer
   }
 
   template <class T>
-  void size(T& t){
+  void size(T&  /*t*/){
     size_ += sizeof(T);
   }
 

--- a/sprockit/sprockit/sim_parameters.cc
+++ b/sprockit/sprockit/sim_parameters.cc
@@ -256,9 +256,9 @@ SimParameters::SimParameters(SimParameters::const_ptr params) :
 }
 
 SimParameters::SimParameters(const key_value_map& p) :
-  params_(p),
   parent_(nullptr),
-  namespace_("global")
+  namespace_("global"),
+  params_(p)
 {
 }
 
@@ -476,7 +476,6 @@ SimParameters::getOptionalTimeParam(const std::string &key,
 double
 SimParameters::getQuantity(const std::string& key)
 {
-  bool error = false;
   std::string value = getParam(key);
   return getQuantityWithUnits(value.c_str(), key.c_str());
 }
@@ -580,7 +579,6 @@ SimParameters::getTokenizer(const std::string& key)
 double
 SimParameters::getFreqParam(const std::string &key)
 {
-  bool errorflag = false;
   std::string param_value_str = getParam(key);
   return get_freq_from_str(param_value_str.c_str(), key.c_str());
 }
@@ -588,7 +586,6 @@ SimParameters::getFreqParam(const std::string &key)
 double
 SimParameters::getOptionalFreqParam(const std::string &key, double def)
 {
-  bool errorflag = false;
   std::string freq_str = printf("%eHz", def);
   std::string param_value_str = getOptionalParam(key, freq_str);
   return get_freq_from_str(param_value_str.c_str(), key.c_str());
@@ -597,7 +594,6 @@ SimParameters::getOptionalFreqParam(const std::string &key, double def)
 long
 SimParameters::getByteLengthParam(const std::string &key)
 {
-  bool errorflag = false;
   std::string param_value_str = getParam(key);
   return get_byte_length_from_str(param_value_str.c_str(), key.c_str());
 }

--- a/sprockit/sprockit/test/assert.h
+++ b/sprockit/sprockit/test/assert.h
@@ -57,7 +57,7 @@ template <class T>
 class InvalidContainer {};
 
 template <class T>
-void invalidContainer(const T& t)
+void invalidContainer(const T&  /*t*/)
 {
   FailCompileTime<true, InvalidContainer<T> > check;
 }

--- a/sprockit/sprockit/test/container.h
+++ b/sprockit/sprockit/test/container.h
@@ -67,7 +67,7 @@ class ContainerAppend
 {
  public:
   static void
-  append(C& c, const A& a) {
+  append(C& c, const A&  /*a*/) {
     invalidContainer(c);
   }
 };

--- a/sprockit/sprockit/thread_safe_new.h
+++ b/sprockit/sprockit/thread_safe_new.h
@@ -89,7 +89,7 @@ class thread_safe_new {
     return allocate(thread);
   }
 
-  static void* operator new(size_t sz, void* ptr){
+  static void* operator new(size_t  /*sz*/, void* ptr){
     return ptr;
   }
 

--- a/sprockit/sprockit/units.cc
+++ b/sprockit/sprockit/units.cc
@@ -323,7 +323,7 @@ populate_length_names(std::map<std::string, int64_t> &value)
   value["GB"] = value["Gbytes"] = value["GBytes"] = one_GB;
   int64_t one_TB = one_GB * 1000LL;
   value["TB"] = value["Tbytes"] = value["TBytes"] = one_TB;
-  int64_t one_KiB = 1024;
+  // TODOWARNING int64_t one_KiB = 1024;
 }
 
 void

--- a/sprockit/sprockit/util.h
+++ b/sprockit/sprockit/util.h
@@ -51,7 +51,7 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace sprockit {
 
 template <class Out, class In>
-Out* __safe_cast__(const char* objname,
+Out* __safe_cast__(const char*  /*objname*/,
               const char* file,
               int line,
               In* in,

--- a/sstmac/backends/common/parallel_runtime.cc
+++ b/sstmac/backends/common/parallel_runtime.cc
@@ -285,11 +285,11 @@ ParallelRuntime::initRuntimeParams(SST::Params& params)
 
 ParallelRuntime::ParallelRuntime(SST::Params& params,
                                    int me, int nproc)
-  : part_(nullptr),
-    me_(me),
-    nproc_(nproc),
+  : nproc_(nproc),
     nthread_(1),
-    epoch_(0)
+    me_(me),
+    epoch_(0),
+    part_(nullptr)
 {
   if (me_ == 0){
     sprockit::output::init_out0(&std::cout);

--- a/sstmac/backends/common/parallel_runtime.cc
+++ b/sstmac/backends/common/parallel_runtime.cc
@@ -74,7 +74,7 @@ ParallelRuntime* ParallelRuntime::static_runtime_ = nullptr;
 static int backupSize = 10e6;
 
 char*
-ParallelRuntime::CommBuffer::allocateSpace(size_t size, IpcEvent *ev)
+ParallelRuntime::CommBuffer::allocateSpace(size_t size, IpcEvent * /*ev*/)
 {
   uint64_t newOffset = add_int64_atomic(size, &bytesAllocated);
   uint64_t myStartPos = newOffset - size;
@@ -283,7 +283,7 @@ ParallelRuntime::initRuntimeParams(SST::Params& params)
 #endif
 }
 
-ParallelRuntime::ParallelRuntime(SST::Params& params,
+ParallelRuntime::ParallelRuntime(SST::Params&  /*params*/,
                                    int me, int nproc)
   : nproc_(nproc),
     nthread_(1),

--- a/sstmac/backends/common/sim_partition.cc
+++ b/sstmac/backends/common/sim_partition.cc
@@ -62,9 +62,9 @@ RegisterDebugSlot(partition);
 namespace sstmac {
 
 Partition::Partition(SST::Params& params, ParallelRuntime* rt) :
-  rt_(rt),
   switch_to_lpid_(nullptr),
-  switch_to_thread_(nullptr)
+  switch_to_thread_(nullptr),
+  rt_(rt)
 {
   nproc_ = rt_->nproc();
   me_ = rt_->me();

--- a/sstmac/backends/common/sim_partition.cc
+++ b/sstmac/backends/common/sim_partition.cc
@@ -61,7 +61,7 @@ RegisterDebugSlot(partition);
 
 namespace sstmac {
 
-Partition::Partition(SST::Params& params, ParallelRuntime* rt) :
+Partition::Partition(SST::Params&  /*params*/, ParallelRuntime* rt) :
   switch_to_lpid_(nullptr),
   switch_to_thread_(nullptr),
   rt_(rt)
@@ -163,7 +163,7 @@ OccupiedBlockPartition::~OccupiedBlockPartition()
 }
 
 void
-BlockPartition::finalizeInit(SST::Params& params)
+BlockPartition::finalizeInit(SST::Params&  /*params*/)
 {
   partitionSwitches();
 }

--- a/sstmac/backends/native/manager.cc
+++ b/sstmac/backends/native/manager.cc
@@ -248,7 +248,6 @@ Manager::Manager(SST::Params& params, ParallelRuntime* rt){}
 // Default constructor.
 //
 Manager::Manager(SST::Params& params, ParallelRuntime* rt) :
-  next_ppid_(0),
   interconnect_(nullptr),
   rt_(rt)
 {

--- a/sstmac/backends/native/manager.h
+++ b/sstmac/backends/native/manager.h
@@ -93,7 +93,7 @@ class Manager {
 
   bool running_;
 
-  sstmac::sw::AppId next_ppid_;
+  // TODOWARNING sstmac::sw::AppId next_ppid_;
 
   sstmac::hw::Interconnect* interconnect_;
   ParallelRuntime* rt_;

--- a/sstmac/backends/native/multithreaded_event_container.cc
+++ b/sstmac/backends/native/multithreaded_event_container.cc
@@ -137,6 +137,7 @@ spin_up_pthread_work(void* args){
   return 0;
 }
 
+#if 0 //TODOWARNING
 static void
 print_backtrace(int sig)
 {
@@ -156,6 +157,7 @@ print_backtrace(int sig)
   sleep(1);
   exit(1);
 }
+#endif
 
 MultithreadedEventContainer::MultithreadedEventContainer(
   SST::Params& params, ParallelRuntime* rt) :
@@ -347,9 +349,12 @@ MultithreadedEventContainer::run()
   //launch all the subthreads - don't launch zero
   //main thread will do zero's work
   int status;
-  int thread_affinity;
   debug_printf(sprockit::dbg::parallel, "spawning %d subthreads",
                num_subthreads_);
+
+#if SSTMAC_USE_CPU_AFFINITY
+  int thread_affinity;
+#endif
   for (int i=0; i < num_subthreads_; ++i){
 #if SSTMAC_USE_CPU_AFFINITY
     //pin the pthread to core base+i

--- a/sstmac/backends/native/serial_runtime.cc
+++ b/sstmac/backends/native/serial_runtime.cc
@@ -81,13 +81,13 @@ SerialRuntime::allgather(void *send_buffer, int num_bytes, void *recv_buffer)
 }
 
 void
-SerialRuntime::send(int dst, void *buffer, int buffer_size)
+SerialRuntime::send(int  /*dst*/, void * /*buffer*/, int  /*buffer_size*/)
 {
   sprockit::abort("serial_runtime::send: should never be called - who would I send to?");
 }
 
 void
-SerialRuntime::recv(int src, void *buffer, int buffer_size)
+SerialRuntime::recv(int  /*src*/, void * /*buffer*/, int  /*buffer_size*/)
 {
   sprockit::abort("serial_runtime::recv: should never be called - who would I recv from?");
 }

--- a/sstmac/common/event_callback.h
+++ b/sstmac/common/event_callback.h
@@ -66,8 +66,8 @@ class MemberFxnCallback :
 
   MemberFxnCallback(Cls* obj, Fxn fxn, const Args&... args) :
     params_(args...),
-    obj_(obj),
-    fxn_(fxn)
+    fxn_(fxn),
+    obj_(obj)
   {
   }
 

--- a/sstmac/common/event_handler.h
+++ b/sstmac/common/event_handler.h
@@ -121,8 +121,8 @@ class MemberFxnHandler : public EventHandler
 
   MemberFxnHandler(Cls* obj, Fxn fxn, const Args&... args) :
     params_(args...),
-    obj_(obj),
-    fxn_(fxn)
+    fxn_(fxn),
+    obj_(obj)
   {
   }
 

--- a/sstmac/common/event_manager.cc
+++ b/sstmac/common/event_manager.cc
@@ -106,15 +106,15 @@ void runEventmanagerThread(void* argPtr)
 }
 
 EventManager::EventManager(SST::Params& params, ParallelRuntime *rt) :
-  rt_(rt),
-  nthread_(rt->nthread()),
-  me_(rt->me()),
-  nproc_(rt->nproc()),
   pendingSlot_(0),
   complete_(false),
-  thread_id_(0),
+  rt_(rt),
+  interconn_(nullptr),
   stopped_(false),
-  interconn_(nullptr)
+  me_(rt->me()),
+  nproc_(rt->nproc()),
+  nthread_(rt->nthread()),
+  thread_id_(0)
 {
   for (int i=0; i < num_pendingSlots; ++i){
     pending_events_[i].resize(nthread_);
@@ -307,7 +307,9 @@ EventManager::scheduleIncoming(IpcEvent* iev)
   qev->setSeqnum(iev->seqnum);
   qev->setTime(iev->t);
   qev->setLink(iev->link);
+#if SSTMAC_SANITY_CHECK
   size_t prev_size = event_queue_.size();
+#endif
   schedule(qev);
 #if SSTMAC_SANITY_CHECK
   if (event_queue_.size() == prev_size){

--- a/sstmac/common/event_manager.h
+++ b/sstmac/common/event_manager.h
@@ -183,7 +183,7 @@ class EventManager
 
   void registerStatisticCore(StatisticBase* base, SST::Params& params);
 
-  virtual EventManager* threadManager(int thr) const {
+  virtual EventManager* threadManager(int  /*thr*/) const {
     return const_cast<EventManager*>(this);
   }
 

--- a/sstmac/common/event_scheduler.cc
+++ b/sstmac/common/event_scheduler.cc
@@ -109,7 +109,7 @@ EventScheduler::getEmptyParams()
 }
 
 void
-EventScheduler::statNotFound(SST::Params &params, const std::string &name, const std::string &type)
+EventScheduler::statNotFound(SST::Params & /*params*/, const std::string &name, const std::string &type)
 {
   spkt_abort_printf("Bad stat type '%s' given for statistic '%s'",
                     type.c_str(), name.c_str());

--- a/sstmac/common/event_scheduler.h
+++ b/sstmac/common/event_scheduler.h
@@ -310,7 +310,7 @@ class EventScheduler : public sprockit::printable
  protected:
   //friend int ::sstmac::run_standalone(int, char**);
 
-  EventScheduler(const std::string& selfname, uint32_t id, SST::Component* base) :
+  EventScheduler(const std::string&  /*selfname*/, uint32_t id, SST::Component* base) :
 #if !SSTMAC_INTEGRATED_SST_CORE
     mgr_(nullptr), 
     seqnum_(0), 
@@ -386,7 +386,7 @@ class Component :
   virtual void init(unsigned int phase); //needed for SST core compatibility
 
  protected:
-  Component(uint32_t cid, SST::Params& params) :
+  Component(uint32_t cid, SST::Params&  /*params*/) :
 #if SSTMAC_INTEGRATED_SST_CORE
    SSTIntegratedComponent(params, cid),
    EventScheduler(cid, this)
@@ -409,11 +409,11 @@ class Component :
 #else
   void initLinks(SST::Params& params){} //need for SST core compatibility
 
-  template <class T> T* loadSub(const std::string& name, SST::Params& params, const std::string& iface){
+  template <class T> T* loadSub(const std::string& name, SST::Params& params, const std::string&  /*iface*/){
     return sprockit::create<T>("macro", name, this, params);
   }
 
-  template <class T> T* newSub(const std::string& name, SST::Params& params){
+  template <class T> T* newSub(const std::string&  /*name*/, SST::Params& params){
     return new T(this, params);
   }
 #endif
@@ -576,7 +576,7 @@ class SubLink : public EventLink
   EventHandler* handler_;
 };
 
-static inline EventLink::ptr allocateSubLink(const std::string& name, TimeDelta lat,
+static inline EventLink::ptr allocateSubLink(const std::string&  /*name*/, TimeDelta lat,
                                              SST::Component* comp, LinkHandler* handler)
 {
   return EventLink::ptr(new SubLink(lat, comp, handler));

--- a/sstmac/common/event_scheduler.h
+++ b/sstmac/common/event_scheduler.h
@@ -57,6 +57,8 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/sst_core/integrated_component.h>
 #include <sprockit/sim_parameters_fwd.h>
 
+#include <unusedvariablemacro.h>
+
 #if SSTMAC_INTEGRATED_SST_CORE
 #include <sst/core/params.h>
 #include <sst/core/link.h>
@@ -310,7 +312,8 @@ class EventScheduler : public sprockit::printable
  protected:
   //friend int ::sstmac::run_standalone(int, char**);
 
-  EventScheduler(const std::string&  /*selfname*/, uint32_t id, SST::Component* base) :
+  EventScheduler(SSTMAC_MAYBE_UNUSED const std::string&  selfname, 
+                 uint32_t id, SST::Component* base) :
 #if !SSTMAC_INTEGRATED_SST_CORE
     mgr_(nullptr), 
     seqnum_(0), 
@@ -386,7 +389,7 @@ class Component :
   virtual void init(unsigned int phase); //needed for SST core compatibility
 
  protected:
-  Component(uint32_t cid, SST::Params&  /*params*/) :
+  Component(uint32_t cid, SSTMAC_MAYBE_UNUSED SST::Params&  params) :
 #if SSTMAC_INTEGRATED_SST_CORE
    SSTIntegratedComponent(params, cid),
    EventScheduler(cid, this)

--- a/sstmac/common/event_scheduler.h
+++ b/sstmac/common/event_scheduler.h
@@ -67,7 +67,9 @@ namespace sstmac {
 class EventLink {
  public:
   EventLink(const std::string& name, TimeDelta selflat, SST::Link* link) :
-    name_(name), selflat_(selflat), link_(link)
+    link_(link),
+    selflat_(selflat), 
+    name_(name)
   {
   }
 
@@ -566,7 +568,10 @@ class SubLink : public EventLink
   }
 
  private:
+#if SSTMAC_INTEGRATED_SST_CORE
   SST::Link* self_link_;
+#endif
+
   Component* comp_;
   EventHandler* handler_;
 };

--- a/sstmac/common/stats/ftq.cc
+++ b/sstmac/common/stats/ftq.cc
@@ -154,13 +154,13 @@ FTQAccumulator::FTQAccumulator(SST::BaseComponent *comp, const std::string &name
 }
 
 void
-FTQAccumulator::registerOutputFields(SST::Statistics::StatisticOutput *statOutput)
+FTQAccumulator::registerOutputFields(SST::Statistics::StatisticOutput * /*statOutput*/)
 {
   sprockit::abort("FTQAccumulator::registerOutputFields: not yet implemented");
 }
 
 void
-FTQAccumulator::outputStatisticData(SST::Statistics::StatisticOutput *statOutput, bool endOfSim)
+FTQAccumulator::outputStatisticData(SST::Statistics::StatisticOutput * /*statOutput*/, bool  /*endOfSim*/)
 {
   sprockit::abort("FTQAccumulator::outputStatisticData: not yet implemented");
 }
@@ -200,13 +200,13 @@ FTQCalendar::addData_impl(int event_typeid, uint64_t ticks_begin, uint64_t num_t
 }
 
 void
-FTQCalendar::registerOutputFields(StatisticFieldsOutput *statOutput)
+FTQCalendar::registerOutputFields(StatisticFieldsOutput * /*statOutput*/)
 {
   sprockit::abort("FTQCalendar::registerOutputFields: should never be called - ensure output is type 'ftq'");
 }
 
 void
-FTQCalendar::outputStatisticData(StatisticFieldsOutput *output, bool endOfSimFlag)
+FTQCalendar::outputStatisticData(StatisticFieldsOutput * /*output*/, bool  /*endOfSimFlag*/)
 {
   sprockit::abort("FTQCalendar::outputStatisticData: should never be called - ensure output is type 'ftq'");
 }
@@ -242,7 +242,7 @@ FTQOutput::startOutputGroup(StatisticGroup *grp)
 }
 
 void
-FTQOutput::output(StatisticBase *statistic, bool endOfSimFlag)
+FTQOutput::output(StatisticBase *statistic, bool  /*endOfSimFlag*/)
 {
   FTQCalendar* calendar = dynamic_cast<FTQCalendar*>(statistic);
   if (!calendar){

--- a/sstmac/common/stats/ftq.cc
+++ b/sstmac/common/stats/ftq.cc
@@ -61,6 +61,8 @@ namespace sstmac {
 
 static sstmac::FTQTag inactive("Inactive", 1);
 
+// TODOWARNING
+#if 0
 static const char* matplotlib_text_header =
     "#!/usr/bin/env python3\n"
     "\n"
@@ -140,6 +142,7 @@ static const char* matplotlib_mean_text_footer =
     "\n"
     "if args.show:\n"
     "    plt.show()\n";
+#endif
 
 
 #if !SSTMAC_INTEGRATED_SST_CORE

--- a/sstmac/common/stats/ftq.h
+++ b/sstmac/common/stats/ftq.h
@@ -85,7 +85,7 @@ class FTQAccumulator : public SST::Statistics::MultiStatistic<int,uint64_t,uint6
   void registerOutputFields(SST::Statistics::StatisticOutput* statOutput) override;
   void outputStatisticData(SST::Statistics::StatisticOutput* statOutput, bool endOfSim) override;
 
-  void addData_impl(int event_typeid, uint64_t ticks_begin, uint64_t num_ticks) override {
+  void addData_impl(int event_typeid, uint64_t  /*ticks_begin*/, uint64_t num_ticks) override {
     event_counts_[event_typeid] += num_ticks;
   }
 

--- a/sstmac/common/stats/stat_accumulator.h
+++ b/sstmac/common/stats/stat_accumulator.h
@@ -79,7 +79,7 @@ class StatAccumulator : public Statistic<T> {
     field_ = statOutput->registerField<T>("total");
   }
 
-  void outputStatisticData(SST::Statistics::StatisticOutput* statOutput, bool EndOfSimFlag) override {
+  void outputStatisticData(SST::Statistics::StatisticOutput* statOutput, bool  /*EndOfSimFlag*/) override {
     statOutput->outputField(field_, total_);
   }
 

--- a/sstmac/common/stats/stat_collector.cc
+++ b/sstmac/common/stats/stat_collector.cc
@@ -59,7 +59,7 @@ SST_ELI_INSTANTIATE_STATISTIC(NullStatistic, double)
 SST_ELI_INSTANTIATE_STATISTIC(NullStatistic, uint64_t)
 SST_ELI_INSTANTIATE_STATISTIC(NullStatistic, void)
 
-StatisticBase::StatisticBase(EventScheduler *parent, const std::string &name,
+StatisticBase::StatisticBase(EventScheduler * /*parent*/, const std::string &name,
                              const std::string &subName, SST::Params &params) :
   name_(name), sub_id_(subName), group_(nullptr)
 {
@@ -134,7 +134,7 @@ StatOutputCSV::outputPending()
 }
 
 void
-Statistic<void>::outputStatisticData(StatisticFieldsOutput *output, bool endOfSimFlag)
+Statistic<void>::outputStatisticData(StatisticFieldsOutput * /*output*/, bool  /*endOfSimFlag*/)
 {
   spkt_abort_printf("void statistic '%s' should never call outputStatisticData\n"
                     "ensure that correct output is set for group '%s'",
@@ -142,7 +142,7 @@ Statistic<void>::outputStatisticData(StatisticFieldsOutput *output, bool endOfSi
 }
 
 void
-Statistic<void>::registerOutputFields(StatisticFieldsOutput *statOutput)
+Statistic<void>::registerOutputFields(StatisticFieldsOutput * /*statOutput*/)
 {
   spkt_abort_printf("void statistic '%s' should never call registerOutputFields\n"
                     "ensure that correct output is set for group '%s'",

--- a/sstmac/common/stats/stat_histogram.h
+++ b/sstmac/common/stats/stat_histogram.h
@@ -67,9 +67,9 @@ class StatHistogram : public SST::Statistics::MultiStatistic<BinType,CountType>
 
   StatHistogram(SST::BaseComponent* comp, const std::string& name,
                 const std::string& subName, SST::Params& params) :
+      SST::Statistics::MultiStatistic<BinType,CountType>(comp, name, subName, params),
       bin_size_(0),
-      is_log_(false),
-      SST::Statistics::MultiStatistic<BinType,CountType>(comp, name, subName, params)
+      is_log_(false)
   {
     min_val_ = params.find<SST::UnitAlgebra>("min_value").getValue().toDouble();
     max_val_ = params.find<SST::UnitAlgebra>("max_value").getValue().toDouble();

--- a/sstmac/common/stats/stat_histogram.h
+++ b/sstmac/common/stats/stat_histogram.h
@@ -115,7 +115,7 @@ class StatHistogram : public SST::Statistics::MultiStatistic<BinType,CountType>
     }
   }
 
-  void outputStatisticData(SST::Statistics::StatisticOutput* statOutput, bool EndOfSimFlag) override {
+  void outputStatisticData(SST::Statistics::StatisticOutput* statOutput, bool  /*EndOfSimFlag*/) override {
     int fid = 0;
     statOutput->outputField(fields_[fid++], int(counts_.size()));
     statOutput->outputField(fields_[fid++], bin_size_);

--- a/sstmac/common/stats/stat_spyplot.h
+++ b/sstmac/common/stats/stat_spyplot.h
@@ -96,7 +96,7 @@ class StatSpyplot : public SST::Statistics::MultiStatistic<Dst,Count>
     }
   }
 
-  void outputStatisticData(SST::Statistics::StatisticOutput* output, bool endOfSim) override {
+  void outputStatisticData(SST::Statistics::StatisticOutput* output, bool  /*endOfSim*/) override {
     for (int i=0; i < n_dst_; ++i){
       output->outputField(fields_[i], vals_[i]);
     }

--- a/sstmac/common/thread_safe_int.h
+++ b/sstmac/common/thread_safe_int.h
@@ -82,7 +82,7 @@ class thread_safe_int_t :
     return tmp;
   }
 
-  Integer operator++(int i){
+  Integer operator++(int  /*i*/){
     Integer tmp(value_);
     lock();
     value_++;

--- a/sstmac/common/timestamp.h
+++ b/sstmac/common/timestamp.h
@@ -107,7 +107,7 @@ class TimeDelta
     }
   }
 
-  explicit TimeDelta(tick_t ticks, timestamp_param_type_t ty) : ticks_(ticks) {}
+  explicit TimeDelta(tick_t ticks, timestamp_param_type_t  /*ty*/) : ticks_(ticks) {}
 
   explicit TimeDelta(uint64_t num_units, tick_t ticks_per_unit) : ticks_(num_units*ticks_per_unit) {}
 

--- a/sstmac/dumpi_util/dumpi_util.cc
+++ b/sstmac/dumpi_util/dumpi_util.cc
@@ -47,6 +47,8 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <cstring>
 #include <sprockit/errors.h>
 
+#include <unusedvariablemacro.h>
+
 namespace sstmac {
 namespace sw {
 
@@ -120,6 +122,7 @@ int undumpi_read_stream(void* profile,
       void *uarg);
 
 
+SSTMAC_MAYBE_UNUSED
 static int dumpi_util_ubuntu_linker_is_an_abomination(){
   return undumpi_read_stream(0,0,0);
 }

--- a/sstmac/hardware/common/recv_cq.h
+++ b/sstmac/hardware/common/recv_cq.h
@@ -83,9 +83,9 @@ class RecvCQ
     uint64_t bytes_arrived;
     uint64_t bytes_total;
     incomingMsg() :
+        msg(0),
         bytes_arrived(0),
-        bytes_total(0),
-        msg(0)
+        bytes_total(0)
     {
     }
   };

--- a/sstmac/hardware/interconnect/interconnect.cc
+++ b/sstmac/hardware/interconnect/interconnect.cc
@@ -335,7 +335,7 @@ uint64_t
 Interconnect::connectLogP(
   uint64_t linkIdOffset,
   EventManager* mgr,
-  SST::Params& node_params,
+  SST::Params&  /*node_params*/,
   SST::Params& nic_params)
 {
   SST::Params inj_params = nic_params.get_namespace("injection");
@@ -431,7 +431,7 @@ Interconnect::connectLogP(
 
 void
 Interconnect::buildEndpoints(SST::Params& node_params,
-                  SST::Params& nic_params,
+                  SST::Params&  /*nic_params*/,
                   EventManager* mgr)
 {
   int my_rank = rt_->me();

--- a/sstmac/hardware/interconnect/interconnect.cc
+++ b/sstmac/hardware/interconnect/interconnect.cc
@@ -240,7 +240,7 @@ Interconnect::connectEndpoints(uint64_t linkIdOffset,
                                SST::Params& sw_params)
 {
   uint64_t linkId = linkIdOffset;
-  int num_nodes = topology_->numNodes();
+  // TODOWARNING int num_nodes = topology_->numNodes();
   int num_switches = topology_->numSwitches();
   int me = rt_->me();
   std::vector<Topology::InjectionPort> ports;
@@ -260,7 +260,7 @@ Interconnect::connectEndpoints(uint64_t linkIdOffset,
   for (int i=0; i < num_switches; ++i){
     //parallel - I don't own this
     int target_rank = partition_->lpidForSwitch(i);
-    int target_thread = partition_->threadForSwitch(i);
+    // TODOWARNING int target_thread = partition_->threadForSwitch(i);
 
     NetworkSwitch* injsw = switches_[i];
     NetworkSwitch* ejsw = switches_[i];
@@ -342,7 +342,7 @@ Interconnect::connectLogP(
   SST::Params empty{};
 
   int my_rank = rt_->me();
-  int my_thread = mgr->thread();
+  // TODOWARNING int my_thread = mgr->thread();
 
   uint64_t linkId = linkIdOffset;
 
@@ -435,7 +435,7 @@ Interconnect::buildEndpoints(SST::Params& node_params,
                   EventManager* mgr)
 {
   int my_rank = rt_->me();
-  int my_thread = mgr->thread();
+  // TODOWARNING int my_thread = mgr->thread();
 
   for (int i=0; i < num_switches_; ++i){
     SwitchId sid(i);

--- a/sstmac/hardware/logp/logp_memory_model.cc
+++ b/sstmac/hardware/logp/logp_memory_model.cc
@@ -80,7 +80,7 @@ LogPMemoryModel::accessFlow(uint64_t bytes, TimeDelta byte_request_delay, Callba
 }
 
 void
-LogPMemoryModel::accessRequest(int linkId, Request *req)
+LogPMemoryModel::accessRequest(int  /*linkId*/, Request * /*req*/)
 {
   spkt_abort_printf("LogP does not support single memory requests - only flow-level calls");
 }

--- a/sstmac/hardware/logp/logp_nic.cc
+++ b/sstmac/hardware/logp/logp_nic.cc
@@ -113,7 +113,7 @@ LogPNIC::doSend(NetworkMessage* msg)
 }
 
 void
-LogPNIC::connectOutput(int src_outport, int dst_inport, EventLink::ptr&& link)
+LogPNIC::connectOutput(int  /*src_outport*/, int  /*dst_inport*/, EventLink::ptr&& link)
 {
   logp_link_ = std::move(link);
 }
@@ -125,7 +125,7 @@ LogPNIC::connectInput(int src_outport, int dst_inport, EventLink::ptr&& link)
 }
 
 LinkHandler*
-LogPNIC::payloadHandler(int port)
+LogPNIC::payloadHandler(int  /*port*/)
 {
   return newLinkHandler(this, &NIC::mtlHandle);
 }

--- a/sstmac/hardware/logp/logp_nic.cc
+++ b/sstmac/hardware/logp/logp_nic.cc
@@ -56,8 +56,8 @@ namespace sstmac {
 namespace hw {
 
 LogPNIC::LogPNIC(SST::Component* parent, SST::Params& params) :
-  next_out_free_(),
-  NIC(parent, params)
+  NIC(parent, params),
+  next_out_free_()
 {
   SST::Params inj_params = params.find_scoped_params("injection");
   inj_byte_delay_ = TimeDelta(inj_params.find<SST::UnitAlgebra>("bandwidth").getValue().inverse().toDouble());

--- a/sstmac/hardware/logp/logp_nic.h
+++ b/sstmac/hardware/logp/logp_nic.h
@@ -95,7 +95,7 @@ class LogPNIC :
     return "simple nic";
   }
 
-  LinkHandler* creditHandler(int port) override {
+  LinkHandler* creditHandler(int  /*port*/) override {
     return newLinkHandler(this, &LogPNIC::dropEvent);
   }
 

--- a/sstmac/hardware/logp/logp_switch.h
+++ b/sstmac/hardware/logp/logp_switch.h
@@ -98,7 +98,7 @@ class LogPSwitch : public ConnectableComponent
     return "LogP switch";
   }
 
-  void connectOutput(int src_outport, int dst_inport, EventLink::ptr&& payload_link) override {
+  void connectOutput(int src_outport, int  /*dst_inport*/, EventLink::ptr&& payload_link) override {
     nic_links_[src_outport] = std::move(payload_link);
   }
 
@@ -106,11 +106,11 @@ class LogPSwitch : public ConnectableComponent
     //do nothing
   }
 
-  LinkHandler* payloadHandler(int port) override {
+  LinkHandler* payloadHandler(int  /*port*/) override {
     return newLinkHandler(this, &LogPSwitch::sendEvent);
   }
 
-  LinkHandler* creditHandler(int port) override {
+  LinkHandler* creditHandler(int  /*port*/) override {
     return newLinkHandler(this, &LogPSwitch::dropEvent);
   }
 

--- a/sstmac/hardware/memory/memory_model.cc
+++ b/sstmac/hardware/memory/memory_model.cc
@@ -56,7 +56,7 @@ namespace hw {
 
 static sprockit::NeedDeletestatics<MemoryModel> need_del;
 
-MemoryModel::MemoryModel(SST::Component* parent_node, SST::Params& params) :
+MemoryModel::MemoryModel(SST::Component* parent_node, SST::Params&  /*params*/) :
   SubComponent("mem", parent_node)
 {
   parent_node_ = safe_cast(Node, parent_node);

--- a/sstmac/hardware/network/network_message.h
+++ b/sstmac/hardware/network/network_message.h
@@ -300,10 +300,10 @@ class NetworkMessage : public Flow
 
   NetworkMessage() : //for serialization
    Flow(-1, 0),
-   qos_(0),
    needs_ack_(true),
    payload_bytes_(0),
-   type_(null_netmsg_type)
+   type_(null_netmsg_type),
+   qos_(0)
   {
   }
 
@@ -323,17 +323,16 @@ class NetworkMessage : public Flow
    void* smsg_buf,
    type_t ty) :
     Flow(flow_id, size, libname),
-    qos_(qos),
     smsg_buffer_(smsg_buf),
     local_buffer_(local_buf),
     remote_buffer_(remote_buf),
-    wire_buffer_(nullptr),
     aid_(aid),
     needs_ack_(needs_ack),
     payload_bytes_(payload_bytes),
     toaddr_(to),
     fromaddr_(from),
-    type_(ty)
+    type_(ty),
+    qos_(qos)
   {
   }
 
@@ -341,16 +340,16 @@ class NetworkMessage : public Flow
 
   void takeBufferOffWire(void* buf, uint64_t sz);
 
-  void* smsg_buffer_;
+  void* smsg_buffer_ = nullptr;
 
-  void* local_buffer_;
+  void* local_buffer_ = nullptr;
 
-  void* remote_buffer_;
+  void* remote_buffer_ = nullptr;
 
   /**
    * @brief wire_buffer Represents a payload injected on the wire
  */
-  void* wire_buffer_;
+  void* wire_buffer_ = nullptr;
 
   sw::AppId aid_;
 

--- a/sstmac/hardware/network/network_message.h
+++ b/sstmac/hardware/network/network_message.h
@@ -94,7 +94,7 @@ class NetworkMessage : public Flow
    uint64_t size,
    bool needs_ack,
    void* buf,
-   header ctor_tag) :
+   header  /*ctor_tag*/) :
     NetworkMessage(qos, flow_id, libname, aid, to, from,
                     size, size, needs_ack, nullptr, nullptr, buf,
                     payload)
@@ -112,7 +112,7 @@ class NetworkMessage : public Flow
    bool needs_ack,
    void* local_buf,
    void* remote_buf,
-   rdma_get ctor_tag) :
+   rdma_get  /*ctor_tag*/) :
     NetworkMessage(qos, flow_id, libname, aid, to, from,
                     64/*default to 64 bytes for now*/,
                     payload_size, needs_ack, local_buf, remote_buf, nullptr,
@@ -131,7 +131,7 @@ class NetworkMessage : public Flow
    bool needs_ack,
    void* local_buf,
    void* remote_buf,
-   rdma_put ctor_tag) :
+   rdma_put  /*ctor_tag*/) :
     NetworkMessage(qos, flow_id, libname, aid, to, from,
                     payload_size, payload_size, needs_ack, local_buf, remote_buf, nullptr,
                     rdma_put_payload)

--- a/sstmac/hardware/nic/nic.cc
+++ b/sstmac/hardware/nic/nic.cc
@@ -93,14 +93,14 @@ NicEvent::validate_serialization(serializable *ser)
 #endif
 
 NIC::NIC(SST::Component* parent, SST::Params& params) :
-  spy_bytes_(nullptr),
-  xmit_flows_(nullptr),
+  ConnectableSubcomponent("nic", parent), //no self events with NIC
   parent_(safe_cast(Node, parent)), //better be a node
   my_addr_(parent_->addr()),
   logp_link_(nullptr),
-  os_(parent_->os()),
+  spy_bytes_(nullptr),
+  xmit_flows_(nullptr),
   queue_(parent_->os()),
-  ConnectableSubcomponent("nic", parent) //no self events with NIC
+  os_(parent_->os())
 {
   negligibleSize_ = params.find<int>("negligible_size", DEFAULT_NEGLIGIBLE_SIZE);
   top_ = Topology::staticTopology(params);

--- a/sstmac/hardware/nic/nic.h
+++ b/sstmac/hardware/nic/nic.h
@@ -266,9 +266,9 @@ class NullNIC : public NIC
 
   void connectInput(int src_outport, int dst_inport, EventLink::ptr&& credit_link) override {}
 
-  LinkHandler* payloadHandler(int port) override { return nullptr; }
+  LinkHandler* payloadHandler(int  /*port*/) override { return nullptr; }
 
-  LinkHandler* creditHandler(int port) override { return nullptr; }
+  LinkHandler* creditHandler(int  /*port*/) override { return nullptr; }
 };
 
 }

--- a/sstmac/hardware/node/node.cc
+++ b/sstmac/hardware/node/node.cc
@@ -208,7 +208,7 @@ Node::connectInput(int src_outport, int dst_inport, EventLink::ptr&& link)
 }
 
 void
-Node::execute(ami::SERVICE_FUNC func, Event* data)
+Node::execute(ami::SERVICE_FUNC  /*func*/, Event*  /*data*/)
 {
   sprockit::abort("node does not implement asynchronous services - choose new node model");
 }

--- a/sstmac/hardware/pisces/pisces.h
+++ b/sstmac/hardware/pisces/pisces.h
@@ -205,8 +205,8 @@ class PiscesCredit :
     int port,
     int vc,
     int num_credits)
-    : port_(port),
-      num_credits_(num_credits),
+    : num_credits_(num_credits),
+      port_(port),
       vc_(vc)
   {
   }

--- a/sstmac/hardware/pisces/pisces_arbitrator.cc
+++ b/sstmac/hardware/pisces/pisces_arbitrator.cc
@@ -43,6 +43,7 @@ Questions? Contact sst-macro-help@sandia.gov
 */
 
 #include <sstmac/hardware/pisces/pisces_arbitrator.h>
+#include <unusedvariablemacro.h>
 
 #include <math.h>
 
@@ -89,6 +90,7 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace sstmac {
 namespace hw {
 
+/* TODOWARNING
 static void
 validate_bw(double test_bw)
 {
@@ -98,6 +100,7 @@ validate_bw(double test_bw)
         test_bw);
   }
 }
+*/
 
 PiscesBandwidthArbitrator::
 PiscesBandwidthArbitrator(double bw)
@@ -106,8 +109,8 @@ PiscesBandwidthArbitrator(double bw)
 }
 
 PiscesSimpleArbitrator::PiscesSimpleArbitrator(double bw) :
-  next_free_(),
-  PiscesBandwidthArbitrator(bw)
+  PiscesBandwidthArbitrator(bw),
+  next_free_()
 {
 }
 
@@ -115,13 +118,13 @@ void
 PiscesSimpleArbitrator::arbitrate(IncomingPacket &st)
 {
   Timestamp start_send = next_free_ < st.now ? st.now : next_free_;
-  TimeDelta arrive_delay = st.pkt->byteLength() * st.pkt->byteDelay();
+  // TODOWARNING TimeDelta arrive_delay = st.pkt->byteLength() * st.pkt->byteDelay();
   TimeDelta output_delay = st.pkt->byteLength() * byteDelay_;
   next_free_ = start_send + output_delay;
   st.pkt->initByteDelay(byteDelay_);
-  TimeDelta creditDelay = output_delay > arrive_delay
-        ? output_delay - arrive_delay //if going out slower, delay credit
-        : TimeDelta();
+  // TODOWARNING TimeDelta creditDelay = output_delay > arrive_delay
+  // TODOWARNING       ? output_delay - arrive_delay //if going out slower, delay credit
+  // TODOWARNING       : TimeDelta();
 
   //store and forward
   //head/tail are linked and go "at same time"
@@ -145,15 +148,15 @@ PiscesNullArbitrator::headTailDelay(PiscesPacket *pkt)
 void
 PiscesNullArbitrator::arbitrate(IncomingPacket &st)
 {
-  PiscesPacket* payload = st.pkt;
+  SSTMAC_MAYBE_UNUSED PiscesPacket* payload = st.pkt;
   pflow_arb_debug_printf_l0("Null: starting packet %p:%llu of size %u with byte_delay=%9.5e epoch_delay=%9.5e: %s",
                             payload, payload->flowId(),
                             payload->numBytes(), payload->byteDelay().sec(), byteDelay_.sec());
   TimeDelta byteDelay = std::max(byteDelay_, st.pkt->byteDelay());
   st.pkt->setByteDelay(byteDelay_);
   TimeDelta actual_delay = st.pkt->numBytes() * byteDelay;
-  TimeDelta min_delay = st.pkt->numBytes() * byteDelay_;
 #if SSTMAC_SANITY_CHECK
+  TimeDelta min_delay = st.pkt->numBytes() * byteDelay_;
   if (actual_delay < min_delay){
     spkt_abort_printf("null arbitrator computed bad delay");
   }
@@ -168,8 +171,8 @@ PiscesNullArbitrator::arbitrate(IncomingPacket &st)
 
 PiscesCutThroughArbitrator::
 PiscesCutThroughArbitrator(double bw)
-  : head_(nullptr),
-    PiscesBandwidthArbitrator(bw)
+  : PiscesBandwidthArbitrator(bw),
+    head_(nullptr)
 {
   cycleLength_ = byteDelay_;
   head_ = Epoch::allocateAtBeginning();

--- a/sstmac/hardware/pisces/pisces_arbitrator.h
+++ b/sstmac/hardware/pisces/pisces_arbitrator.h
@@ -157,7 +157,7 @@ class PiscesSimpleArbitrator :
     return "pisces simple arbitrator";
   }
 
-  TimeDelta headTailDelay(PiscesPacket *pkt) override {
+  TimeDelta headTailDelay(PiscesPacket * /*pkt*/) override {
     //no delay
     return TimeDelta();
   }

--- a/sstmac/hardware/pisces/pisces_branched_switch.cc
+++ b/sstmac/hardware/pisces/pisces_branched_switch.cc
@@ -166,7 +166,7 @@ PiscesBranchedSwitch::connectInput(int src_outport, int dst_inport, EventLink::p
 }
 
 int
-PiscesBranchedSwitch::queueLength(int port, int vc) const
+PiscesBranchedSwitch::queueLength(int  /*port*/, int  /*vc*/) const
 {
   spkt_abort_printf("unimplemented: PiscesTiledSwitch::queueLength");
   return 0;

--- a/sstmac/hardware/pisces/pisces_buffer.cc
+++ b/sstmac/hardware/pisces/pisces_buffer.cc
@@ -63,14 +63,14 @@ PiscesBuffer::~PiscesBuffer()
 }
 
 void
-PiscesBuffer::setInput(int this_inport, int src_outport, EventLink::ptr&& link)
+PiscesBuffer::setInput(int  /*this_inport*/, int src_outport, EventLink::ptr&& link)
 {
   input_.link = std::move(link);
   input_.port_to_credit = src_outport;
 }
 
 void
-PiscesBuffer::setOutput(int this_outport, int dst_inport, EventLink::ptr&& link, int credits)
+PiscesBuffer::setOutput(int  /*this_outport*/, int dst_inport, EventLink::ptr&& link, int credits)
 {
   output_.link = std::move(link);
   output_.arrival_port = dst_inport;

--- a/sstmac/hardware/pisces/pisces_crossbar.cc
+++ b/sstmac/hardware/pisces/pisces_crossbar.cc
@@ -92,14 +92,14 @@ PiscesNtoMQueue(const std::string& selfname, uint32_t id,
                 int num_in_ports, int num_out_ports, int num_vc,
                 bool update_vc)
   : PiscesSender(selfname, id, parent, update_vc),
-    num_vc_(num_vc),
 #if SSTMAC_SANITY_CHECK
     initial_credits_(num_vc * num_out_ports),
 #endif
-    queues_(num_vc * num_out_ports),
-    credits_(num_vc * num_out_ports),
     inputs_(num_in_ports),
-    outputs_(num_out_ports)
+    outputs_(num_out_ports),
+    credits_(num_vc * num_out_ports),
+    queues_(num_vc * num_out_ports),
+    num_vc_(num_vc)
 
 {
   arb_ = sprockit::create<PiscesBandwidthArbitrator>("macro", arb, bw);

--- a/sstmac/hardware/pisces/pisces_memory_model.cc
+++ b/sstmac/hardware/pisces/pisces_memory_model.cc
@@ -67,8 +67,8 @@ namespace hw {
 
 
 PiscesMemoryModel::PiscesMemoryModel(SST::Component* nd, SST::Params& params) :
-  arb_(nullptr),
-  MemoryModel(nd, params)
+  MemoryModel(nd, params),
+  arb_(nullptr)
 {
   nchannels_ = params.find<int>("nchannels", 8);
   channels_available_.resize(nchannels_);

--- a/sstmac/hardware/pisces/pisces_nic.cc
+++ b/sstmac/hardware/pisces/pisces_nic.cc
@@ -108,7 +108,7 @@ PiscesNIC::payloadHandler(int port)
 }
 
 LinkHandler*
-PiscesNIC::creditHandler(int port)
+PiscesNIC::creditHandler(int  /*port*/)
 {
   return newLinkHandler(this, &PiscesNIC::packetSent);
 }
@@ -126,7 +126,7 @@ PiscesNIC::connectOutput(int src_outport, int dst_inport, EventLink::ptr&& link)
 }
 
 void
-PiscesNIC::connectInput(int src_outport, int dst_inport, EventLink::ptr&& link)
+PiscesNIC::connectInput(int  /*src_outport*/, int dst_inport, EventLink::ptr&& link)
 {
   if (dst_inport == Injection){ //the logp port is not for credits!
     credit_link_ = std::move(link);

--- a/sstmac/hardware/pisces/pisces_nic.h
+++ b/sstmac/hardware/pisces/pisces_nic.h
@@ -130,7 +130,7 @@ class PiscesNIC : public NIC
   EventLink::ptr credit_link_;
   EventLink::ptr self_mtl_link_;
 
-  NodeId my_addr_;
+  // TODOWARNING NodeId my_addr_;
 
   uint32_t packet_size_;
   uint32_t inj_credits_;

--- a/sstmac/hardware/pisces/pisces_sender.cc
+++ b/sstmac/hardware/pisces/pisces_sender.cc
@@ -52,8 +52,8 @@ Questions? Contact sst-macro-help@sandia.gov
 
 MakeDebugSlot(pisces_timeline)
 
-static int num_sends = 0;
-static int num_credits = 0;
+// TODOWARNING static int num_sends = 0;
+// TODOWARNING static int num_credits = 0;
 
 namespace sstmac {
 namespace hw {

--- a/sstmac/hardware/pisces/pisces_switch.cc
+++ b/sstmac/hardware/pisces/pisces_switch.cc
@@ -193,7 +193,7 @@ PiscesSwitch::InputPort::handle(Event *ev)
 }
 
 void
-PiscesSwitch::connectInput(int src_outport, int dst_inport, EventLink::ptr&& link)
+PiscesSwitch::connectInput(int  /*src_outport*/, int dst_inport, EventLink::ptr&& link)
 {
   int buffer_port = 0;
   xbar_->setInput(dst_inport, buffer_port, std::move(link));

--- a/sstmac/hardware/pisces/pisces_switch.cc
+++ b/sstmac/hardware/pisces/pisces_switch.cc
@@ -66,8 +66,8 @@ namespace sstmac {
 namespace hw {
 
 PiscesAbstractSwitch::PiscesAbstractSwitch(uint32_t id, SST::Params& params) :
-  router_(nullptr),
-  NetworkSwitch(id, params)
+  NetworkSwitch(id, params),
+  router_(nullptr)
 {
   SST::Params rtr_params = params.find_scoped_params("router");
   rtr_params.insert("id", std::to_string(my_addr_));

--- a/sstmac/hardware/pisces/pisces_tiled_switch.cc
+++ b/sstmac/hardware/pisces/pisces_tiled_switch.cc
@@ -206,7 +206,7 @@ PiscesTiledSwitch::connectInput(int src_outport, int dst_inport, EventLink::ptr&
 }
 
 int
-PiscesTiledSwitch::queueLength(int port, int vc) const
+PiscesTiledSwitch::queueLength(int  /*port*/, int  /*vc*/) const
 {
   spkt_throw_printf(sprockit::UnimplementedError,
     "PiscesTiledSwitch::queue_length");
@@ -259,13 +259,13 @@ PiscesTiledSwitch::toString() const
 }
 
 LinkHandler*
-PiscesTiledSwitch::creditHandler(int port)
+PiscesTiledSwitch::creditHandler(int  /*port*/)
 {
   return newLinkHandler(this, &PiscesTiledSwitch::handleCredit);
 }
 
 LinkHandler*
-PiscesTiledSwitch::payloadHandler(int port)
+PiscesTiledSwitch::payloadHandler(int  /*port*/)
 {
   return newLinkHandler(this, &PiscesTiledSwitch::handlePayload);
 }

--- a/sstmac/hardware/router/dragonfly_routing.cc
+++ b/sstmac/hardware/router/dragonfly_routing.cc
@@ -381,7 +381,7 @@ class DragonflyUGALRouter : public DragonflyValiantRouter {
     uint32_t seed = netsw_->now().time.ticks();
     uint32_t attempt = 0;
     int new_g = dst_g;
-    bool go_valiant = false;
+    // TODOWARNING bool go_valiant = false;
     auto hdr = pkt->rtrHeader<header>();
     int min_port = group_ports_[dst_g][group_port_rotaters_[dst_g]];
     if (dfly_->g() > 2){ //can't do this unless I have an intermediate group!

--- a/sstmac/hardware/router/torus_routing.cc
+++ b/sstmac/hardware/router/torus_routing.cc
@@ -196,7 +196,7 @@ class TorusValiantRouter : public TorusMinimalRouter {
     return 4;
   }
 
-  SwitchId getIntermediate(Packet* pkt, SwitchId ej_addr){
+  SwitchId getIntermediate(Packet*  /*pkt*/, SwitchId ej_addr){
     uint32_t seed = netsw_->now().time.ticks();
     uint32_t attempt = 0;
     SwitchId new_sw = ej_addr;

--- a/sstmac/hardware/sculpin/sculpin.cc
+++ b/sstmac/hardware/sculpin/sculpin.cc
@@ -62,8 +62,8 @@ SculpinPacket::SculpinPacket(
   uint64_t flow_id,
   NodeId toaddr,
   NodeId fromaddr) :
-  priority_(0),
-  Packet(msg, num_bytes, flow_id, is_tail, fromaddr, toaddr)
+  Packet(msg, num_bytes, flow_id, is_tail, fromaddr, toaddr),
+  priority_(0)
 {
 }
 

--- a/sstmac/hardware/sculpin/sculpin_nic.cc
+++ b/sstmac/hardware/sculpin/sculpin_nic.cc
@@ -98,13 +98,13 @@ SculpinNIC::payloadHandler(int port)
 }
 
 LinkHandler*
-SculpinNIC::creditHandler(int port)
+SculpinNIC::creditHandler(int  /*port*/)
 {
   return newLinkHandler(this, &SculpinNIC::handleCredit);
 }
 
 void
-SculpinNIC::connectOutput(int src_outport, int dst_inport, EventLink::ptr&& link)
+SculpinNIC::connectOutput(int src_outport, int  /*dst_inport*/, EventLink::ptr&& link)
 {
   if (src_outport == Injection){
     inj_link_ = std::move(link);
@@ -202,7 +202,7 @@ SculpinNIC::handlePayload(Event *ev)
 }
 
 void
-SculpinNIC::handleCredit(Event *ev)
+SculpinNIC::handleCredit(Event * /*ev*/)
 {
   spkt_abort_printf("SculpinNIC::handleCredit: should not handle credits in sculpin model");
 }

--- a/sstmac/hardware/sculpin/sculpin_switch.cc
+++ b/sstmac/hardware/sculpin/sculpin_switch.cc
@@ -160,7 +160,7 @@ SculpinSwitch::connectInput(int src_outport, int dst_inport, EventLink::ptr&& li
 }
 
 int
-SculpinSwitch::queueLength(int port, int vc) const
+SculpinSwitch::queueLength(int port, int  /*vc*/) const
 {
   auto& p = ports_[port];
   //VC basically ignored, all ports on "same" VC
@@ -168,7 +168,7 @@ SculpinSwitch::queueLength(int port, int vc) const
 }
 
 void
-SculpinSwitch::handleCredit(Event *ev)
+SculpinSwitch::handleCredit(Event * /*ev*/)
 {
   spkt_abort_printf("SculpinSwitch::handleCredit: should never be called");
 }
@@ -331,13 +331,13 @@ SculpinSwitch::toString() const
 }
 
 LinkHandler*
-SculpinSwitch::creditHandler(int port)
+SculpinSwitch::creditHandler(int  /*port*/)
 {
   return newLinkHandler(this, &SculpinSwitch::handleCredit);
 }
 
 LinkHandler*
-SculpinSwitch::payloadHandler(int port)
+SculpinSwitch::payloadHandler(int  /*port*/)
 {
   return newLinkHandler(this, &SculpinSwitch::handlePayload);
 }

--- a/sstmac/hardware/sculpin/sculpin_switch.cc
+++ b/sstmac/hardware/sculpin/sculpin_switch.cc
@@ -83,10 +83,10 @@ namespace sstmac {
 namespace hw {
 
 SculpinSwitch::SculpinSwitch(uint32_t id, SST::Params& params) :
+  NetworkSwitch(id, params),
   router_(nullptr),
-  congestion_(true),
-  vtk_(nullptr),
-  NetworkSwitch(id, params)
+  // TODOWARNING vtk_(nullptr),
+  congestion_(true)
 {
   SST::Params rtr_params = params.find_scoped_params("router");
   rtr_params.insert("id", std::to_string(my_addr_));
@@ -186,7 +186,7 @@ SculpinSwitch::send(Port& p, SculpinPacket* pkt, Timestamp now)
   pkt->setTimeToSend(time_to_send);
   p.link->send(extra_delay, pkt);
 
-  TimeDelta delay = p.next_free - pkt->arrival();
+  // TODOWARNING TimeDelta delay = p.next_free - pkt->arrival();
 
   //if (xmit_delay_) xmit_delay_->addData(p.id, delay.usec());
 
@@ -254,7 +254,7 @@ SculpinSwitch::tryToSendPacket(SculpinPacket* pkt)
   Port& p = ports_[pkt->nextPort()];
   pkt->setSeqnum(p.seqnum++);
 
-  static int max_queue_depth = 0;
+  // TODOWARNING static int max_queue_depth = 0;
 
   if (!congestion_){
     TimeDelta time_to_send = pkt->numBytes() * p.byte_delay;

--- a/sstmac/hardware/sculpin/sculpin_switch.h
+++ b/sstmac/hardware/sculpin/sculpin_switch.h
@@ -141,7 +141,7 @@ class SculpinSwitch :
 
   Router* router_;
 
-  SST::Statistics::MultiStatistic<uint64_t/*time*/,int/*port*/,double/*color*/,int/*id*/>* vtk_;
+  // TODOWARNING SST::Statistics::MultiStatistic<uint64_t/*time*/,int/*port*/,double/*color*/,int/*id*/>* vtk_;
 
 #if SSTMAC_VTK_ENABLED
 #if SSTMAC_INTEGRATED_SST_CORE

--- a/sstmac/hardware/snappr/snappr.cc
+++ b/sstmac/hardware/snappr/snappr.cc
@@ -66,11 +66,11 @@ SnapprPacket::SnapprPacket(
   NodeId toaddr,
   NodeId fromaddr,
   int qos) :
+  Packet(msg, num_bytes, flow_id, is_tail, fromaddr, toaddr),
   offset_(offset),
-  priority_(0),
-  inport_(-1),
   qos_(qos),
-  Packet(msg, num_bytes, flow_id, is_tail, fromaddr, toaddr)
+  priority_(0),
+  inport_(-1)
 {
 }
 

--- a/sstmac/hardware/snappr/snappr.h
+++ b/sstmac/hardware/snappr/snappr.h
@@ -203,8 +203,8 @@ class SnapprCredit :
  public:
   SnapprCredit(uint32_t num_bytes, int vl, int port) :
     num_bytes_(num_bytes),
-    port_(port),
-    vl_(vl)
+    vl_(vl),
+    port_(port)
   {
   }
 

--- a/sstmac/hardware/snappr/snappr_mem.cc
+++ b/sstmac/hardware/snappr/snappr_mem.cc
@@ -12,8 +12,9 @@ namespace sstmac {
 namespace hw {
 
 SnapprMemoryModel::SnapprMemoryModel(SST::Component *nd, SST::Params &params) :
-  channelInterleaver_(0), flowId_(0),
-  MemoryModel(nd, params)
+  MemoryModel(nd, params),
+  flowId_(0),
+  channelInterleaver_(0)
 {
   flow_mtu_ = params.find<SST::UnitAlgebra>("flow_mtu", "512").getRoundedValue();
 

--- a/sstmac/hardware/snappr/snappr_nic.cc
+++ b/sstmac/hardware/snappr/snappr_nic.cc
@@ -138,7 +138,7 @@ SnapprNIC::payloadHandler(int port)
 }
 
 LinkHandler*
-SnapprNIC::creditHandler(int port)
+SnapprNIC::creditHandler(int  /*port*/)
 {
   return newLinkHandler(this, &SnapprNIC::handleCredit);
 }
@@ -314,7 +314,7 @@ SnapprNIC::handleTailPacket(Timestamp done, SnapprPacket* pkt)
 }
 
 void
-SnapprNIC::injectPacket(uint32_t ptk_size, uint64_t byte_offset, NetworkMessage* payload)
+SnapprNIC::injectPacket(uint32_t  /*ptk_size*/, uint64_t byte_offset, NetworkMessage* payload)
 {
   uint64_t bytes_left = payload->byteLength() - byte_offset;
   uint32_t pkt_size = std::min(bytes_left, uint64_t(packet_size_));
@@ -349,7 +349,7 @@ struct FIFOQueue : public SnapprNIC::InjectionQueue {
     "fifo",
     "implements a FIFO strategy for injecting packets")
 
-  FIFOQueue(SST::Params& p){}
+  FIFOQueue(SST::Params&  /*p*/){}
 
   std::pair<uint64_t, NetworkMessage*> top() override {
     return queue_.front();
@@ -432,7 +432,7 @@ struct RoundRobinQueue : public SnapprNIC::InjectionQueue {
     "round_robin",
     "implements a round-robin strategy for injecting packets")
 
-  RoundRobinQueue(SST::Params& p) :
+  RoundRobinQueue(SST::Params&  /*p*/) :
     begin_(0), end_(0), queue_(1024){}
 
   std::pair<uint64_t, NetworkMessage*> top() override {

--- a/sstmac/hardware/snappr/snappr_outport.cc
+++ b/sstmac/hardware/snappr/snappr_outport.cc
@@ -283,9 +283,9 @@ struct FifoPortArbitrator : public SnapprPortArbitrator
     "fifo",
     "implements a FIFO strategy for queuing packets")
 
-  FifoPortArbitrator(TimeDelta link_byte_delay, SST::Params& params){}
+  FifoPortArbitrator(TimeDelta  /*link_byte_delay*/, SST::Params&  /*params*/){}
 
-  void insert(uint64_t cycle, SnapprPacket *pkt) override {
+  void insert(uint64_t  /*cycle*/, SnapprPacket *pkt) override {
     VirtualLane& vl = vls_[pkt->virtualLane()];
     vl.occupancy += 1;
     if (vl.credits >= pkt->numBytes()){
@@ -334,7 +334,7 @@ struct FifoPortArbitrator : public SnapprPortArbitrator
     }
   }
 
-  SnapprPacket* pop(uint64_t cycle) override {
+  SnapprPacket* pop(uint64_t  /*cycle*/) override {
     SnapprPacket* pkt = port_queue_.front();
     port_debug("FIFO %p VL %d popping packet", this, pkt->virtualLane());
     port_queue_.pop();
@@ -358,11 +358,11 @@ struct ScatterPortArbitrator : public SnapprPortArbitrator
   };
 
  public:
-  ScatterPortArbitrator(SST::Params& params){
+  ScatterPortArbitrator(SST::Params&  /*params*/){
     //nothing to do
   }
 
-  void insert(uint64_t cycle, SnapprPacket *pkt) override {
+  void insert(uint64_t  /*cycle*/, SnapprPacket *pkt) override {
     VirtualLane& vl = vls_[pkt->virtualLane()];
     if (vl.credits >= pkt->numBytes()){
       port_queue_.emplace(pkt);
@@ -372,7 +372,7 @@ struct ScatterPortArbitrator : public SnapprPortArbitrator
     }
   }
 
-  SnapprPacket* pop(uint64_t cycle) override {
+  SnapprPacket* pop(uint64_t  /*cycle*/) override {
     SnapprPacket* pkt = port_queue_.top();
     port_queue_.pop();
     return pkt;

--- a/sstmac/hardware/snappr/snappr_outport.cc
+++ b/sstmac/hardware/snappr/snappr_outport.cc
@@ -26,12 +26,17 @@ SnapprOutPort::SnapprOutPort(SST::Params& params, const std::string &arb,
                              const std::string& subId, const std::string& portName,
                              int number, TimeDelta byt_delay, bool congestion, bool flow_control,
                              Component* parent)
-  : arbitration_scheduled(false), inports(nullptr),
-    portName_(subId), number_(number),
+  : arbitration_scheduled(false), 
+    byte_delay(byt_delay), 
     state_ftq(nullptr),
     queue_depth_ftq(nullptr),
-    byte_delay(byt_delay), congestion_(congestion), flow_control_(flow_control),
-    parent_(parent), notifier_(nullptr)
+    inports(nullptr),
+    parent_(parent), 
+    flow_control_(flow_control),
+    congestion_(congestion), 
+    portName_(subId), 
+    number_(number),
+    notifier_(nullptr)
 {
   arb_ = sprockit::create<SnapprPortArbitrator>("macro", arb, byte_delay, params);
   xmit_active = parent->registerStatistic<uint64_t>(params, "xmit_active", subId);

--- a/sstmac/hardware/snappr/snappr_switch.cc
+++ b/sstmac/hardware/snappr/snappr_switch.cc
@@ -74,8 +74,8 @@ static FTQTag active("active_port", 0);
 static FTQTag stalled("stalled_port", 0);
 
 SnapprSwitch::SnapprSwitch(uint32_t id, SST::Params& params) :
-  router_(nullptr),
-  NetworkSwitch(id, params)
+  NetworkSwitch(id, params),
+  router_(nullptr)
 {
   SST::Params rtr_params = params.find_scoped_params("router");
   rtr_params.insert("id", std::to_string(my_addr_));

--- a/sstmac/hardware/snappr/snappr_switch.cc
+++ b/sstmac/hardware/snappr/snappr_switch.cc
@@ -164,7 +164,7 @@ SnapprSwitch::connectInput(int src_outport, int dst_inport, EventLink::ptr&& lin
 }
 
 int
-SnapprSwitch::queueLength(int port, int vc) const
+SnapprSwitch::queueLength(int port, int  /*vc*/) const
 {
   auto& p = outports_[port];
   //VC basically ignored, all ports on "same" VC

--- a/sstmac/hardware/snappr/snappr_switch.h
+++ b/sstmac/hardware/snappr/snappr_switch.h
@@ -109,7 +109,7 @@ class SnapprSwitch :
   void deadlockCheck() override;
 
  private:
-  friend class SnapprInPort;
+  friend struct SnapprInPort;
 
   void handlePayload(SnapprPacket* ev, int port);
 

--- a/sstmac/hardware/topology/cascade.cc
+++ b/sstmac/hardware/topology/cascade.cc
@@ -51,6 +51,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sprockit/util.h>
 #include <sprockit/keyword_registration.h>
 #include <sprockit/sim_parameters.h>
+#include <unusedvariablemacro.h>
 
 RegisterKeywords(
 { "topology_group_connections", "DEPRECATED: for group-based topologies, number of group connections per router" },
@@ -60,6 +61,7 @@ RegisterKeywords(
 namespace sstmac {
 namespace hw {
 
+SSTMAC_MAYBE_UNUSED
 static const double PI = 3.141592653589793238462;
 
 Cascade::Cascade(SST::Params& params) :
@@ -97,7 +99,7 @@ bool
 Cascade::xy_connected_to_group(int myX, int myY, int myG, int dstg) const
 {
   int gstride = std::max(1, g_ / group_con_);
-  int gconns = 0;
+  // TODOWARNING int gconns = 0;
   int my_group_id = myX + myY * x_;
   int goffset = my_group_id % g_;
   int theg = myG + goffset;

--- a/sstmac/hardware/topology/cascade.cc
+++ b/sstmac/hardware/topology/cascade.cc
@@ -286,7 +286,7 @@ Cascade::connectedOutports(SwitchId src, std::vector<Connection>& conns) const
 }
 
 double
-Cascade::portScaleFactor(uint32_t addr, int port) const
+Cascade::portScaleFactor(uint32_t  /*addr*/, int port) const
 {
   if (port >= (x_+y_)){
     //group port

--- a/sstmac/hardware/topology/dragonfly.cc
+++ b/sstmac/hardware/topology/dragonfly.cc
@@ -142,7 +142,7 @@ Dragonfly::minimalDistance(SwitchId src, SwitchId dst) const
 }
 
 std::string
-Dragonfly::portTypeName(SwitchId sid, int port) const
+Dragonfly::portTypeName(SwitchId  /*sid*/, int port) const
 {
   if (port < a_){
     return "intra";
@@ -198,7 +198,7 @@ Dragonfly::connectedOutports(SwitchId src, std::vector<Connection>& conns) const
 }
 
 bool
-Dragonfly::isCurvedVtkLink(SwitchId sid, int port) const
+Dragonfly::isCurvedVtkLink(SwitchId  /*sid*/, int port) const
 {
   if (port >= a_){
     return false; //global link - these are straight lines
@@ -324,7 +324,7 @@ Dragonfly::portConfigDump(const std::string &dump_file)
   ofs.close();
 }
 
-InterGroupWiring::InterGroupWiring(SST::Params& params, int a, int g, int h) :
+InterGroupWiring::InterGroupWiring(SST::Params&  /*params*/, int a, int g, int h) :
   a_(a), g_(g), h_(h)
 {
 }
@@ -374,7 +374,7 @@ class SingleLinkGroupWiring : public InterGroupWiring
     }
   }
 
-  int inputGroupPort(int srcA, int srcG, int srcH, int dstA, int dstG) const override {
+  int inputGroupPort(int  /*srcA*/, int  /*srcG*/, int srcH, int  /*dstA*/, int  /*dstG*/) const override {
     if (srcH != 0){
       spkt_abort_printf("h must be 1 for single link inter-group pattern");
     }
@@ -446,7 +446,7 @@ class CirculantGroupWiring : public InterGroupWiring
     }
   }
 
-  int inputGroupPort(int srcA, int srcG, int srcH, int dstA, int dstG) const override {
+  int inputGroupPort(int  /*srcA*/, int  /*srcG*/, int srcH, int  /*dstA*/, int  /*dstG*/) const override {
     if (srcH % 2 == 0){
       return srcH + 1;
     } else {
@@ -532,7 +532,7 @@ class AllToAllGroupWiring : public InterGroupWiring
     if (a_ % covering_) spkt_abort_printf("dragonfly covering=%d must evenly divide group_size=%d", covering_, a_);
   }
 
-  int inputGroupPort(int srcA, int srcG, int srcH, int dstA, int dstG) const override {
+  int inputGroupPort(int srcA, int srcG, int  /*srcH*/, int dstA, int dstG) const override {
     int deltaA = modulo(srcA - dstA,a_); //mod arithmetic in case srcA < dstA
     int offset = deltaA / stride_;
     if (srcG < dstG){
@@ -590,7 +590,7 @@ class AllToAllGroupWiring : public InterGroupWiring
    *                  is the "port offset", a unique index for the group link
    * @return The number of routers in group srcG with connections to dstG
    */
-  void connectedToGroup(int srcG, int dstG, std::vector<std::pair<int,int>>& connected) const override {
+  void connectedToGroup(int  /*srcG*/, int dstG, std::vector<std::pair<int,int>>& connected) const override {
     connected.clear();
     for (int a=0; a < a_; ++a){
       int offset = dstG * covering_;

--- a/sstmac/hardware/topology/dragonfly.cc
+++ b/sstmac/hardware/topology/dragonfly.cc
@@ -69,7 +69,7 @@ RegisterKeywords(
 namespace sstmac {
 namespace hw {
 
-static const double PI = 3.141592653589793238462;
+// TODOWARNING static const double PI = 3.141592653589793238462;
 
 Dragonfly::Dragonfly(SST::Params& params) :
   CartesianTopology(params)
@@ -336,7 +336,7 @@ InterGroupWiring::randomIntermediate(Router* rtr, SwitchId current_sw, SwitchId 
   int srcG = current_sw / g_;
   int dstA = dest_sw % g_;
   int dstG = dest_sw / g_;
-  SwitchId sid = current_sw;
+  // TODOWARNING SwitchId sid = current_sw;
   uint32_t attempt = 0;
   if (srcG == dstG){
     int interA = srcA;

--- a/sstmac/hardware/topology/dragonfly_plus.cc
+++ b/sstmac/hardware/topology/dragonfly_plus.cc
@@ -62,7 +62,7 @@ RegisterKeywords(
 namespace sstmac {
 namespace hw {
 
-static const double PI = 3.141592653589793238462;
+// TODOWARNING static const double PI = 3.141592653589793238462;
 
 DragonflyPlus::DragonflyPlus(SST::Params& params) :
   Dragonfly(params)

--- a/sstmac/hardware/topology/dragonfly_plus.h
+++ b/sstmac/hardware/topology/dragonfly_plus.h
@@ -130,7 +130,7 @@ class DragonflyPlus : public Dragonfly
     return num_leaf_switches_;
   }
 
-  bool isCurvedVtkLink(SwitchId sid, int port) const override {
+  bool isCurvedVtkLink(SwitchId  /*sid*/, int  /*port*/) const override {
     return false;
   }
 

--- a/sstmac/hardware/topology/fat_tree.cc
+++ b/sstmac/hardware/topology/fat_tree.cc
@@ -151,7 +151,7 @@ FatTree::FatTree(SST::Params& params) :
 }
 
 Topology::VTKSwitchGeometry
-FatTree::getVtkGeometry(SwitchId sid) const
+FatTree::getVtkGeometry(SwitchId  /*sid*/) const
 {
   // TODOWARNING int core_row_cutoff = num_leaf_switches_ + num_agg_switches_;
   // TODOWARNING int agg_row_cutoff = num_leaf_switches_;
@@ -359,7 +359,7 @@ FatTree::connectedOutports(SwitchId src, std::vector<Connection>& conns) const
 }
 
 double
-FatTree::portScaleFactor(uint32_t addr, int port) const
+FatTree::portScaleFactor(uint32_t addr, int  /*port*/) const
 {
   int my_level = level(addr);
 
@@ -570,12 +570,12 @@ TaperedFatTree::endpointsConnectedToInjectionSwitch(SwitchId swaddr,
 
 void
 TaperedFatTree::createPartition(
-  int *switch_to_lp,
-  int *switch_to_thread,
-  int me,
-  int nproc,
-  int nthread,
-  int noccupied) const
+  int * /*switch_to_lp*/,
+  int * /*switch_to_thread*/,
+  int  /*me*/,
+  int  /*nproc*/,
+  int  /*nthread*/,
+  int  /*noccupied*/) const
 {
   spkt_throw_printf(sprockit::UnimplementedError, "tapered_fat_tree::createPartition");
 /**
@@ -638,7 +638,7 @@ TaperedFatTree::createPartition(
 }
 
 double
-TaperedFatTree::portScaleFactor(uint32_t addr, int port) const
+TaperedFatTree::portScaleFactor(uint32_t  /*addr*/, int  /*port*/) const
 {
   return 1.0;
 }

--- a/sstmac/hardware/topology/fat_tree.cc
+++ b/sstmac/hardware/topology/fat_tree.cc
@@ -143,8 +143,8 @@ FatTree::FatTree(SST::Params& params) :
   down_ports_per_core_switch_ =
       params.find<int>("down_ports_per_core_switch");
 
-  int leaf_ports = concentration() + up_ports_per_leaf_switch_;
-  int agg_ports = down_ports_per_agg_switch_ +  up_ports_per_agg_switch_;
+  // TODOWARNING int leaf_ports = concentration() + up_ports_per_leaf_switch_;
+  // TODOWARNING int agg_ports = down_ports_per_agg_switch_ +  up_ports_per_agg_switch_;
 
   // check for errors
   checkInput();
@@ -153,9 +153,9 @@ FatTree::FatTree(SST::Params& params) :
 Topology::VTKSwitchGeometry
 FatTree::getVtkGeometry(SwitchId sid) const
 {
-  int core_row_cutoff = num_leaf_switches_ + num_agg_switches_;
-  int agg_row_cutoff = num_leaf_switches_;
-  int num_in_row = 0;
+  // TODOWARNING int core_row_cutoff = num_leaf_switches_ + num_agg_switches_;
+  // TODOWARNING int agg_row_cutoff = num_leaf_switches_;
+  // TODOWARNING int num_in_row = 0;
   int row = 0;
   int slot = 0;
   int subtree = 0;
@@ -294,7 +294,7 @@ FatTree::connectedOutports(SwitchId src, std::vector<Connection>& conns) const
         / agg_switches_per_subtree_;
     int my_subtree_spot = (src - num_leaf_switches_)
         % agg_switches_per_subtree_;
-    int agg_spot = src - num_leaf_switches_;
+    // TODOWARNING int agg_spot = src - num_leaf_switches_;
     // up ports
     for (int up_port=0; up_port < up_ports_per_agg_switch_; ++up_port){
       int global_core_down_port =

--- a/sstmac/hardware/topology/fat_tree.h
+++ b/sstmac/hardware/topology/fat_tree.h
@@ -275,8 +275,8 @@ class FatTree :
   int up_ports_per_agg_switch_;
   int down_ports_per_core_switch_;
 
-  double leaf_agg_bw_;
-  double agg_core_bw_;
+  // TODOWARNING double leaf_agg_bw_;
+  // TODOWARNING double agg_core_bw_;
 
   void checkInput() const;
 };

--- a/sstmac/hardware/topology/fat_tree.h
+++ b/sstmac/hardware/topology/fat_tree.h
@@ -194,7 +194,7 @@ class FatTree :
     return -1;
   }
 
-  bool isCurvedVtkLink(SwitchId sid, int port) const override {
+  bool isCurvedVtkLink(SwitchId  /*sid*/, int  /*port*/) const override {
     return false;
   }
 

--- a/sstmac/hardware/topology/file.h
+++ b/sstmac/hardware/topology/file.h
@@ -95,12 +95,12 @@ class FileTopology : public Topology
     return num_leaf_switches_;
   }
 
-  int minimalDistance(SwitchId src, SwitchId dst) const {
+  int minimalDistance(SwitchId  /*src*/, SwitchId  /*dst*/) const {
     spkt_abort_printf("minimalDistance() not implemented");
     return 0;
   }
 
-  int numHopsToNode(NodeId src, NodeId dst) const override {
+  int numHopsToNode(NodeId  /*src*/, NodeId  /*dst*/) const override {
     // extremely approximate
     return num_hops_;
   }

--- a/sstmac/hardware/topology/fully_connected.h
+++ b/sstmac/hardware/topology/fully_connected.h
@@ -85,11 +85,11 @@ class FullyConnected : public StructuredTopology
     return size_;
   }
 
-  int minimalDistance(SwitchId src, SwitchId dst) const {
+  int minimalDistance(SwitchId  /*src*/, SwitchId  /*dst*/) const {
     return 1;
   }
 
-  int numHopsToNode(NodeId src, NodeId dst) const override {
+  int numHopsToNode(NodeId  /*src*/, NodeId  /*dst*/) const override {
     return 1;
   }
 

--- a/sstmac/hardware/topology/hypercube.cc
+++ b/sstmac/hardware/topology/hypercube.cc
@@ -120,7 +120,7 @@ Hypercube::minimalDistance(
 }
 
 double
-Hypercube::portScaleFactor(uint32_t addr, int port) const
+Hypercube::portScaleFactor(uint32_t  /*addr*/, int port) const
 {
   int port_cutoff = 0;
   int dim=0; 
@@ -139,7 +139,7 @@ Hypercube::portScaleFactor(uint32_t addr, int port) const
 }
 
 std::string
-Hypercube::portTypeName(SwitchId sid, int port) const
+Hypercube::portTypeName(SwitchId  /*sid*/, int port) const
 {
   static const char* dimNames[] = {"X","Y","Z","A","B"};
 

--- a/sstmac/hardware/topology/star.cc
+++ b/sstmac/hardware/topology/star.cc
@@ -55,7 +55,7 @@ Star::Star(SST::Params& params) :
 }
 
 void
-Star::connectedOutports(SwitchId src, std::vector<Connection>& conns) const
+Star::connectedOutports(SwitchId  /*src*/, std::vector<Connection>& conns) const
 {
   conns.resize(0);
 }

--- a/sstmac/hardware/topology/star.h
+++ b/sstmac/hardware/topology/star.h
@@ -85,11 +85,11 @@ class Star : public StructuredTopology
     return 1;
   }
 
-  int minimalDistance(SwitchId src, SwitchId dst) const {
+  int minimalDistance(SwitchId  /*src*/, SwitchId  /*dst*/) const {
     return 1;
   }
 
-  int numHopsToNode(NodeId src, NodeId dst) const override {
+  int numHopsToNode(NodeId  /*src*/, NodeId  /*dst*/) const override {
     return 1;
   }
 

--- a/sstmac/hardware/topology/topology.cc
+++ b/sstmac/hardware/topology/topology.cc
@@ -231,12 +231,12 @@ Topology::outputXYZ(const std::string& path)
 
 void
 Topology::createPartition(
-  int *switch_to_lp,
-  int *switch_to_thread,
-  int me,
-  int nproc,
-  int nthread,
-  int noccupied) const
+  int * /*switch_to_lp*/,
+  int * /*switch_to_thread*/,
+  int  /*me*/,
+  int  /*nproc*/,
+  int  /*nthread*/,
+  int  /*noccupied*/) const
 {
   spkt_throw_printf(sprockit::UnimplementedError,
     "topology::partition: not valid for %s",
@@ -274,7 +274,7 @@ Topology::label(uint32_t comp_id) const
 }
 
 Topology::VTKSwitchGeometry
-Topology::getVtkGeometry(SwitchId sid) const
+Topology::getVtkGeometry(SwitchId  /*sid*/) const
 {
   spkt_abort_printf("unimplemented: topology::getVtkGeometry for %s",
                     toString().c_str());
@@ -302,7 +302,7 @@ Topology::nodeNameToId(const std::string& hostname) const
 }
 
 void
-Topology::initHostnameMap(SST::Params& params)
+Topology::initHostnameMap(SST::Params&  /*params*/)
 {
   if (!idmap_.empty() || !hostmap_.empty()){
     spkt_abort_printf("topology::initHostnameMap: maps not empty");
@@ -328,7 +328,7 @@ Topology::dumpPorts()
 }
 
 void
-Topology::portConfigDump(const std::string &dumpFile)
+Topology::portConfigDump(const std::string & /*dumpFile*/)
 {
   spkt_abort_printf("Topology chosen does not support port dump");
 }
@@ -367,7 +367,7 @@ class MerlinTopology : public Topology {
     return 0;
   }
 
-  void connectedOutports(SwitchId src, std::vector<Topology::Connection>& conns) const override {
+  void connectedOutports(SwitchId  /*src*/, std::vector<Topology::Connection>&  /*conns*/) const override {
     spkt_abort_printf("merlin topology functions should never be called");
   }
 
@@ -376,18 +376,18 @@ class MerlinTopology : public Topology {
     return -1;
   }
 
-  int numHopsToNode(NodeId src, NodeId dst) const override {
+  int numHopsToNode(NodeId  /*src*/, NodeId  /*dst*/) const override {
     spkt_abort_printf("merlin topology functions should never be called");
     return -1;
   }
 
-  void endpointsConnectedToInjectionSwitch(SwitchId swid,
-                          std::vector<InjectionPort>& nodes) const override {
+  void endpointsConnectedToInjectionSwitch(SwitchId  /*swid*/,
+                          std::vector<InjectionPort>&  /*nodes*/) const override {
     spkt_abort_printf("merlin topology functions should never be called");
   }
 
-  void endpointsConnectedToEjectionSwitch(SwitchId swid,
-                          std::vector<InjectionPort>& nodes) const override {
+  void endpointsConnectedToEjectionSwitch(SwitchId  /*swid*/,
+                          std::vector<InjectionPort>&  /*nodes*/) const override {
     spkt_abort_printf("merlin topology functions should never be called");
   }
 

--- a/sstmac/hardware/topology/topology.h
+++ b/sstmac/hardware/topology/topology.h
@@ -325,7 +325,7 @@ class Topology : public sprockit::printable
  public:
   virtual ~Topology();
 
-  virtual double portScaleFactor(uint32_t addr, int port) const {
+  virtual double portScaleFactor(uint32_t  /*addr*/, int  /*port*/) const {
     return 1.0;
   }
 
@@ -376,7 +376,7 @@ class Topology : public sprockit::printable
    */
   virtual VTKSwitchGeometry getVtkGeometry(SwitchId sid) const;
 
-  virtual bool isCurvedVtkLink(SwitchId sid, int port) const {
+  virtual bool isCurvedVtkLink(SwitchId  /*sid*/, int  /*port*/) const {
     return false;
   }
 
@@ -501,7 +501,7 @@ class Topology : public sprockit::printable
     return std::string("switch") + std::to_string(id);
   }
 
-  virtual std::string portTypeName(SwitchId sid, int port) const {
+  virtual std::string portTypeName(SwitchId  /*sid*/, int  /*port*/) const {
     return "network";
   }
 

--- a/sstmac/hardware/topology/torus.cc
+++ b/sstmac/hardware/topology/torus.cc
@@ -53,14 +53,14 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace sstmac {
 namespace hw {
 
-static bool
-equals(const std::vector<int>& coords, int x, int y, int z)
-{
-  if (coords.size() != 3) {
-    return false;
-  }
-  return coords[0] == x && coords[1] == y && coords[2] == z;
-}
+// TODOWARNING static bool
+// TODOWARNING equals(const std::vector<int>& coords, int x, int y, int z)
+// TODOWARNING {
+// TODOWARNING   if (coords.size() != 3) {
+// TODOWARNING     return false;
+// TODOWARNING   }
+// TODOWARNING   return coords[0] == x && coords[1] == y && coords[2] == z;
+// TODOWARNING }
 
 Torus::Torus(SST::Params& params) :
   CartesianTopology(params)

--- a/sstmac/hardware/topology/torus.cc
+++ b/sstmac/hardware/topology/torus.cc
@@ -143,7 +143,7 @@ Torus::shortestPathPositive(
 }
 
 double
-Torus::portScaleFactor(uint32_t addr, int port) const
+Torus::portScaleFactor(uint32_t  /*addr*/, int port) const
 {
   if (port >= 2*dimensions_.size()){
     //ejection port

--- a/sstmac/libraries/blas/blas_api.cc
+++ b/sstmac/libraries/blas/blas_api.cc
@@ -136,7 +136,7 @@ BlasAPI::daxpy(int n)
 }
 
 ComputeEvent*
-BlasKernel::op_3d(int m, int k, int n)
+BlasKernel::op_3d(int  /*m*/, int  /*k*/, int  /*n*/)
 {
   spkt_throw_printf(sprockit::UnimplementedError,
     "blas_kernel::mult_op: %s does not implement 3D ops",
@@ -144,7 +144,7 @@ BlasKernel::op_3d(int m, int k, int n)
 }
 
 ComputeEvent*
-BlasKernel::op_2d(int m, int n)
+BlasKernel::op_2d(int  /*m*/, int  /*n*/)
 {
   spkt_throw_printf(sprockit::UnimplementedError,
     "blas_kernel::mult_op: %s does not implement 2D ops",
@@ -152,7 +152,7 @@ BlasKernel::op_2d(int m, int n)
 }
 
 ComputeEvent*
-BlasKernel::op_1d(int n)
+BlasKernel::op_1d(int  /*n*/)
 {
   spkt_throw_printf(sprockit::UnimplementedError,
     "blas_kernel::mult_op: %s does not implement 1D ops",

--- a/sstmac/libraries/blas/cblas.cc
+++ b/sstmac/libraries/blas/cblas.cc
@@ -64,10 +64,10 @@ sstmac_simple_dgemm(int m, int n, int k)
 }
 
 extern "C" void
-sstmac_dgemm(char *transa, char *transb, int* m, int* n, int* k, 
-  double* alpha, double* a, int* lda, 
-  double* b, int* ldb, double* beta, 
-  double* c, int* ldc
+sstmac_dgemm(char * /*transa*/, char * /*transb*/, int* m, int* n, int* k, 
+  double*  /*alpha*/, double*  /*a*/, int*  /*lda*/, 
+  double*  /*b*/, int*  /*ldb*/, double*  /*beta*/, 
+  double*  /*c*/, int*  /*ldc*/
 )
 {
   sstmac_simple_dgemm(*m, *n, *k);
@@ -80,10 +80,10 @@ sstmac_simple_dgemv(int m, int n)
 }
 
 extern "C" void
-sstmac_dgemv(char *transa, int* m, int* n,
-  double* alpha, double* a, int* lda,
-  double* x, int* incx, double* beta,
-  double* y, int* incy
+sstmac_dgemv(char * /*transa*/, int* m, int* n,
+  double*  /*alpha*/, double*  /*a*/, int*  /*lda*/,
+  double*  /*x*/, int*  /*incx*/, double*  /*beta*/,
+  double*  /*y*/, int*  /*incy*/
 )
 {
   sstmac_simple_dgemv(*m, *n);
@@ -98,9 +98,9 @@ sstmac_simple_daxpy(int n)
 
 extern "C" void
 sstmac_daxpy(int* n,
-  double* alpha,
-  double* x, int* incx,
-  double* y, int* incy
+  double*  /*alpha*/,
+  double*  /*x*/, int*  /*incx*/,
+  double*  /*y*/, int*  /*incy*/
 )
 {
   sstmac_simple_daxpy(*n);
@@ -114,8 +114,8 @@ sstmac_simple_ddot(int n)
 
 extern "C" void
 sstmac_ddot(int* n,
-  double* x, int* incx,
-  double* y, int* incy)
+  double*  /*x*/, int*  /*incx*/,
+  double*  /*y*/, int*  /*incy*/)
 {
   sstmac_simple_ddot(*n);
 }

--- a/sstmac/libraries/machines/bgp.cc
+++ b/sstmac/libraries/machines/bgp.cc
@@ -52,7 +52,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 extern "C"
 void
-Kernel_GetPersonality(_BGP_Personality_t *p, int size)
+Kernel_GetPersonality(_BGP_Personality_t *p, int  /*size*/)
 {
   sstmac::NodeId nid = sstmac::Runtime::current_node();
   SST::Params empty{};

--- a/sstmac/libraries/pthread/sstmac_pthread.cc
+++ b/sstmac/libraries/pthread/sstmac_pthread.cc
@@ -113,7 +113,7 @@ SSTMAC_pthread_yield()
 }
 
 extern "C" void
-SSTMAC_pthread_exit(void *retval)
+SSTMAC_pthread_exit(void * /*retval*/)
 {
   pthread_debug("pthread_exit");
   Thread* current = currentThread();
@@ -121,7 +121,7 @@ SSTMAC_pthread_exit(void *retval)
 }
 
 extern "C" int
-SSTMAC_pthread_kill(sstmac_pthread_t thread, int sig)
+SSTMAC_pthread_kill(sstmac_pthread_t  /*thread*/, int  /*sig*/)
 {
   sprockit::abort("pthread_kill: not implemented");
   return -1;
@@ -132,7 +132,7 @@ SSTMAC_pthread_kill(sstmac_pthread_t thread, int sig)
  *      - status currently not set, don't use it
  */
 extern "C" int
-SSTMAC_pthread_join(sstmac_pthread_t pthread, void ** status)
+SSTMAC_pthread_join(sstmac_pthread_t pthread, void **  /*status*/)
 {
   pthread_debug("pthread_join");
   Thread* current_thr = currentThread();
@@ -180,14 +180,14 @@ SSTMAC_pthread_equal(sstmac_pthread_t thread_1, sstmac_pthread_t thread_2)
 }
 
 extern "C" int
-SSTMAC_pthread_mutexattr_gettype(const sstmac_pthread_mutexattr_t* attr, int* type)
+SSTMAC_pthread_mutexattr_gettype(const sstmac_pthread_mutexattr_t*  /*attr*/, int* type)
 {
   *type = SSTMAC_PTHREAD_MUTEX_NORMAL;
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_mutexattr_settype(sstmac_pthread_mutexattr_t *attr, int type)
+SSTMAC_pthread_mutexattr_settype(sstmac_pthread_mutexattr_t * /*attr*/, int type)
 {
   if (type == SSTMAC_PTHREAD_MUTEX_NORMAL){
     return 0;
@@ -197,7 +197,7 @@ SSTMAC_pthread_mutexattr_settype(sstmac_pthread_mutexattr_t *attr, int type)
 }
 
 extern "C" int
-SSTMAC_pthread_spin_init(sstmac_pthread_spinlock_t* lock, int pshared)
+SSTMAC_pthread_spin_init(sstmac_pthread_spinlock_t* lock, int  /*pshared*/)
 
 {
   return SSTMAC_pthread_mutex_init(lock, NULL);  
@@ -205,7 +205,7 @@ SSTMAC_pthread_spin_init(sstmac_pthread_spinlock_t* lock, int pshared)
 
 extern "C" int
 SSTMAC_pthread_mutex_init(sstmac_pthread_mutex_t * mutex,
-                          const sstmac_pthread_mutexattr_t *attr)
+                          const sstmac_pthread_mutexattr_t * /*attr*/)
 {
   pthread_debug("pthread_mutex_init");
   Thread* thr = currentThread();
@@ -360,14 +360,14 @@ class UnblockEvent : public ExecutionEvent
 
 
 extern "C" int
-SSTMAC_pthread_mutexattr_init(sstmac_pthread_mutexattr_t *attr)
+SSTMAC_pthread_mutexattr_init(sstmac_pthread_mutexattr_t * /*attr*/)
 {
   pthread_debug("pthread_mutexattr_init");
   return 0; //no op for now
 }
 
 extern "C" int
-SSTMAC_pthread_mutexattr_destroy(sstmac_pthread_mutexattr_t *attr)
+SSTMAC_pthread_mutexattr_destroy(sstmac_pthread_mutexattr_t * /*attr*/)
 {
   pthread_debug("pthread_mutexattr_destroy");
   return 0; //no op for now
@@ -375,7 +375,7 @@ SSTMAC_pthread_mutexattr_destroy(sstmac_pthread_mutexattr_t *attr)
 
 extern "C" int
 SSTMAC_pthread_cond_init(sstmac_pthread_cond_t * cond,
-                         const sstmac_pthread_condattr_t *attr)
+                         const sstmac_pthread_condattr_t * /*attr*/)
 {
   pthread_debug("pthread_cond_init");  
   //just intialize it
@@ -500,7 +500,7 @@ SSTMAC_pthread_cond_signal(sstmac_pthread_cond_t * cond)
 }
 
 extern "C" int
-SSTMAC_pthread_cond_broadcast(sstmac_pthread_cond_t * cond)
+SSTMAC_pthread_cond_broadcast(sstmac_pthread_cond_t *  /*cond*/)
 {
   pthread_debug("pthread_cond_broadcast");  
   spkt_throw_printf(sprockit::UnimplementedError,
@@ -508,14 +508,14 @@ SSTMAC_pthread_cond_broadcast(sstmac_pthread_cond_t * cond)
 }
 
 extern "C" int
-SSTMAC_pthread_condattr_getpshared(const sstmac_pthread_condattr_t* attr, int* pshared)
+SSTMAC_pthread_condattr_getpshared(const sstmac_pthread_condattr_t*  /*attr*/, int* pshared)
 {
   *pshared = SSTMAC_PTHREAD_PROCESS_PRIVATE;
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_condattr_setpshared(sstmac_pthread_condattr_t* attr, int pshared)
+SSTMAC_pthread_condattr_setpshared(sstmac_pthread_condattr_t*  /*attr*/, int pshared)
 {
   if (pshared != SSTMAC_PTHREAD_PROCESS_PRIVATE){
     sprockit::abort("SST does not yet support PTHREAD_PROCESS_SHARED condition");
@@ -583,13 +583,13 @@ SSTMAC_pthread_getspecific(sstmac_pthread_key_t key)
 }
 
 extern "C" void
-SSTMAC_pthread_cleanup_pop(int execute)
+SSTMAC_pthread_cleanup_pop(int  /*execute*/)
 {
   sprockit::abort("not implemented: pthread_cleanup_pop");
 }
 
 extern "C" void
-SSTMAC_pthread_cleanup_push(void (*routine)(void*), void* arg)
+SSTMAC_pthread_cleanup_push(void (* /*routine*/)(void*), void*  /*arg*/)
 {
   sprockit::abort("not implemented: pthread_cleanup_push");
 }
@@ -606,27 +606,27 @@ SSTMAC_pthread_attr_init(sstmac_pthread_attr_t *attr)
 }
 
 extern "C" int
-SSTMAC_pthread_attr_destroy(sstmac_pthread_attr_t *attr)
+SSTMAC_pthread_attr_destroy(sstmac_pthread_attr_t * /*attr*/)
 {
   return 0; //no op for now
 }
 
 extern "C" int
-SSTMAC_pthread_attr_setaffinity_np(sstmac_pthread_attr_t *attr, size_t cpusetsize, const sstmac_cpu_set_t *cpuset)
+SSTMAC_pthread_attr_setaffinity_np(sstmac_pthread_attr_t *attr, size_t  /*cpusetsize*/, const sstmac_cpu_set_t *cpuset)
 {
   attr->cpumask = cpuset->cpubits;
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_attr_getaffinity_np(sstmac_pthread_attr_t attr, size_t cpusetsize, sstmac_cpu_set_t *cpuset)
+SSTMAC_pthread_attr_getaffinity_np(sstmac_pthread_attr_t attr, size_t  /*cpusetsize*/, sstmac_cpu_set_t *cpuset)
 {
   cpuset->cpubits = attr.cpumask;
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_attr_getstack(sstmac_pthread_attr_t *attr, void **stack, size_t *stacksize)
+SSTMAC_pthread_attr_getstack(sstmac_pthread_attr_t * /*attr*/, void **stack, size_t *stacksize)
 {
   *stack = nullptr;
   *stacksize = sstmac::sw::OperatingSystem::stacksize();
@@ -634,15 +634,15 @@ SSTMAC_pthread_attr_getstack(sstmac_pthread_attr_t *attr, void **stack, size_t *
 }
 
 extern "C" int
-SSTMAC_pthread_attr_getstacksize(sstmac_pthread_attr_t *attr,
-                                 size_t * stacksize)
+SSTMAC_pthread_attr_getstacksize(sstmac_pthread_attr_t * /*attr*/,
+                                 size_t *  /*stacksize*/)
 {
   spkt_throw_printf(sprockit::UnimplementedError,
                    "pthread::pthread_attr_getstacksize not implemented");
 }
 
 extern "C" int
-SSTMAC_pthread_attr_setstacksize(sstmac_pthread_attr_t *attr, size_t stacksize)
+SSTMAC_pthread_attr_setstacksize(sstmac_pthread_attr_t * /*attr*/, size_t  /*stacksize*/)
 {
   return EPERM;
   spkt_throw_printf(sprockit::UnimplementedError,
@@ -691,56 +691,56 @@ SSTMAC_pthread_detach(sstmac_pthread_t thr)
 }
 
 extern "C" int
-SSTMAC_pthread_rwlock_rdlock(sstmac_pthread_rwlock_t *rwlock)
+SSTMAC_pthread_rwlock_rdlock(sstmac_pthread_rwlock_t * /*rwlock*/)
 {
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_rwlock_tryrdlock(sstmac_pthread_rwlock_t *rwlock)
+SSTMAC_pthread_rwlock_tryrdlock(sstmac_pthread_rwlock_t * /*rwlock*/)
 {
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_rwlock_wrlock(sstmac_pthread_rwlock_t *rwlock)
+SSTMAC_pthread_rwlock_wrlock(sstmac_pthread_rwlock_t * /*rwlock*/)
 {
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_rwlock_trywrlock(sstmac_pthread_rwlock_t *rwlock)
+SSTMAC_pthread_rwlock_trywrlock(sstmac_pthread_rwlock_t * /*rwlock*/)
 {
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_rwlock_destroy(sstmac_pthread_rwlock_t *rwlock)
+SSTMAC_pthread_rwlock_destroy(sstmac_pthread_rwlock_t * /*rwlock*/)
 {
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_rwlock_init(sstmac_pthread_rwlock_t *rwlock,
-       const sstmac_pthread_rwlockattr_t *attr)
+SSTMAC_pthread_rwlock_init(sstmac_pthread_rwlock_t * /*rwlock*/,
+       const sstmac_pthread_rwlockattr_t * /*attr*/)
 {
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_rwlock_unlock(sstmac_pthread_rwlock_t* rwlock)
+SSTMAC_pthread_rwlock_unlock(sstmac_pthread_rwlock_t*  /*rwlock*/)
 {
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_rwlockattr_init(sstmac_pthread_rwlockattr_t *attr)
+SSTMAC_pthread_rwlockattr_init(sstmac_pthread_rwlockattr_t * /*attr*/)
 {
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_rwlockattr_destroy(sstmac_pthread_rwlockattr_t *attr)
+SSTMAC_pthread_rwlockattr_destroy(sstmac_pthread_rwlockattr_t * /*attr*/)
 {
   return 0;
 }
@@ -761,22 +761,22 @@ SSTMAC_pthread_getconcurrency()
 }
 
 extern "C" int
-SSTMAC_pthread_atfork(void (*prepare)(void), void (*parent)(void),
-       void (*child)(void))
+SSTMAC_pthread_atfork(void (* /*prepare*/)(void), void (* /*parent*/)(void),
+       void (* /*child*/)(void))
 {
   sprockit::abort("not implemented: pthread_atfork");
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_mutexattr_getpshared(const sstmac_pthread_mutexattr_t* attr, int* pshared)
+SSTMAC_pthread_mutexattr_getpshared(const sstmac_pthread_mutexattr_t*  /*attr*/, int* pshared)
 {
   *pshared = SSTMAC_PTHREAD_PROCESS_PRIVATE;
   return 0;
 }
 
 extern "C" int
-SSTMAC_pthread_mutexattr_setpshared(sstmac_pthread_mutexattr_t* attr, int pshared)
+SSTMAC_pthread_mutexattr_setpshared(sstmac_pthread_mutexattr_t*  /*attr*/, int pshared)
 {
   if (pshared != SSTMAC_PTHREAD_PROCESS_PRIVATE){
     sprockit::abort("SST does not yet support PTHREAD_PROCESS_SHARED mutex");

--- a/sstmac/libraries/pthread/sstmac_sched.cc
+++ b/sstmac/libraries/pthread/sstmac_sched.cc
@@ -49,28 +49,28 @@ Questions? Contact sst-macro-help@sandia.gov
 
 /* Set scheduling parameters for a process.  */
 extern "C" int
-SSTMAC_sched_setparam (pid_t pid, const struct sstmac_sched_param *param){
+SSTMAC_sched_setparam (pid_t  /*pid*/, const struct sstmac_sched_param * /*param*/){
   sprockit::abort("sched_setparam: not implemented");
   return 0;
 }
 
 /* Retrieve scheduling parameters for a particular process.  */
 extern "C" int
-SSTMAC_sched_getparam (pid_t pid, struct sstmac_sched_param *param){
+SSTMAC_sched_getparam (pid_t  /*pid*/, struct sstmac_sched_param * /*param*/){
   sprockit::abort("sched_getparam: not implemented");
   return 0;
 }
 
 /* Set scheduling algorithm and/or parameters for a process.  */
 extern "C" int
-SSTMAC_sched_setscheduler (pid_t pid, int policy,  const struct sstmac_sched_param *param){
+SSTMAC_sched_setscheduler (pid_t  /*pid*/, int  /*policy*/,  const struct sstmac_sched_param * /*param*/){
   sprockit::abort("sched_setscheduler: not implemented");
   return 0;
 }
 
 /* Retrieve scheduling algorithm for a particular purpose.  */
 extern "C" int
-SSTMAC_sched_getscheduler (pid_t pid){
+SSTMAC_sched_getscheduler (pid_t  /*pid*/){
   sprockit::abort("sched_getscheduler: not implemented");
   return 0;
 }
@@ -85,7 +85,7 @@ SSTMAC_sched_yield (void){
 
 /* Get the SCHED_RR interval for the named process.  */
 extern "C" int
-SSTMAC_sched_rr_get_interval (pid_t pid, struct timespec *t){
+SSTMAC_sched_rr_get_interval (pid_t  /*pid*/, struct timespec * /*t*/){
   sprockit::abort("sched_rr_get_interval: not implemented");
   return 0;
 }
@@ -107,7 +107,7 @@ SSTMAC_CPU_CLR_S (int cpu, size_t setsize, sstmac_cpu_set_t* cpusetp){
 }
 
 extern "C" int
-SSTMAC_CPU_ISSET_S (int cpu, size_t setsize, sstmac_cpu_set_t* cpusetp){
+SSTMAC_CPU_ISSET_S (int cpu, size_t  /*setsize*/, sstmac_cpu_set_t* cpusetp){
   return cpusetp->cpubits & (1<<cpu);
 }
 
@@ -131,27 +131,27 @@ SSTMAC_count_bits(sstmac_cpu_set_t* cpusetp){
 }
 
 extern "C" int
-SSTMAC_CPU_COUNT_S (size_t setsize, sstmac_cpu_set_t* cpusetp){
+SSTMAC_CPU_COUNT_S (size_t  /*setsize*/, sstmac_cpu_set_t* cpusetp){
   return SSTMAC_count_bits(cpusetp);
 }
 
 extern "C" int
-SSTMAC_CPU_EQUAL_S(size_t setsize, sstmac_cpu_set_t* cpusetp1, sstmac_cpu_set_t* cpusetp2){
+SSTMAC_CPU_EQUAL_S(size_t  /*setsize*/, sstmac_cpu_set_t* cpusetp1, sstmac_cpu_set_t*  /*cpusetp2*/){
   return cpusetp1->cpubits == cpusetp1->cpubits;
 }
 
 extern "C" void
-SSTMAC_CPU_AND_S(size_t setsize, sstmac_cpu_set_t* destset, sstmac_cpu_set_t* srcset1, sstmac_cpu_set_t* srcset2){
+SSTMAC_CPU_AND_S(size_t  /*setsize*/, sstmac_cpu_set_t* destset, sstmac_cpu_set_t* srcset1, sstmac_cpu_set_t* srcset2){
   destset->cpubits = srcset1->cpubits & srcset2->cpubits;
 }
 
 extern "C" void
-SSTMAC_CPU_OR_S(size_t setsize, sstmac_cpu_set_t* destset, sstmac_cpu_set_t* srcset1, sstmac_cpu_set_t* srcset2){
+SSTMAC_CPU_OR_S(size_t  /*setsize*/, sstmac_cpu_set_t* destset, sstmac_cpu_set_t* srcset1, sstmac_cpu_set_t* srcset2){
   destset->cpubits = srcset1->cpubits | srcset2->cpubits;
 }
 
 extern "C" void
-SSTMAC_CPU_XOR_S(size_t setsize, sstmac_cpu_set_t* destset, sstmac_cpu_set_t* srcset1, sstmac_cpu_set_t* srcset2){
+SSTMAC_CPU_XOR_S(size_t  /*setsize*/, sstmac_cpu_set_t* destset, sstmac_cpu_set_t* srcset1, sstmac_cpu_set_t* srcset2){
   destset->cpubits = srcset1->cpubits ^ srcset2->cpubits;
 }
 
@@ -170,7 +170,7 @@ void SSTMAC_CPU_FREE(sstmac_cpu_set_t* cpuset){
 
 /* Set the CPU affinity for a task */
 extern "C" int
-SSTMAC_sched_setaffinity (pid_t pid, size_t cpusetsize, const sstmac_cpu_set_t *cpuset){
+SSTMAC_sched_setaffinity (pid_t  /*pid*/, size_t  /*cpusetsize*/, const sstmac_cpu_set_t *cpuset){
   sstmac::sw::OperatingSystem* os = sstmac::sw::OperatingSystem::currentOs();
   sstmac::sw::Thread* t = os->activeThread();
   t->setCpumask(cpuset->cpubits);
@@ -185,7 +185,7 @@ SSTMAC_sched_setaffinity (pid_t pid, size_t cpusetsize, const sstmac_cpu_set_t *
 
 /* Get the CPU affinity for a task */
 extern "C" int
-SSTMAC_sched_getaffinity (pid_t pid, size_t cpusetsize, sstmac_cpu_set_t *cpuset){
+SSTMAC_sched_getaffinity (pid_t  /*pid*/, size_t  /*cpusetsize*/, sstmac_cpu_set_t *cpuset){
   sstmac::sw::Thread* t = sstmac::sw::OperatingSystem::currentThread();
   cpuset->cpubits = t->cpumask();
   return 0;

--- a/sstmac/libraries/pthread/sstmac_sched.h
+++ b/sstmac/libraries/pthread/sstmac_sched.h
@@ -73,12 +73,12 @@ extern int SSTMAC_sched_getscheduler (pid_t pid);
 extern int SSTMAC_sched_yield (void);
 
 /* Get maximum priority value for a scheduler.  */
-static inline int SSTMAC_sched_get_priority_max (int algorithm){
+static inline int SSTMAC_sched_get_priority_max (int  /*algorithm*/){
   return 99;
 }
 
 /* Get minimum priority value for a scheduler.  */
-static inline int SSTMAC_sched_get_priority_min (int algorithm){
+static inline int SSTMAC_sched_get_priority_min (int  /*algorithm*/){
   return 1;
 }
 

--- a/sstmac/main/help.cc
+++ b/sstmac/main/help.cc
@@ -46,7 +46,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <cstring>
 
 void
-printHelp(int argc, char **argv)
+printHelp(int  /*argc*/, char **argv)
 {
   char *name = argv[0];
   char *tail = name + strlen(name);

--- a/sstmac/main/params.cc
+++ b/sstmac/main/params.cc
@@ -162,7 +162,7 @@ param_remap remap_list[] = {
 void
 remapParams(sprockit::SimParameters::ptr params, bool verbose)
 {
-  double timescale = 100e-18;//params->get_optional_time_param("timestamp_resolution", 100e-18);
+  // TODOWARNING double timescale = 100e-18;//params->get_optional_time_param("timestamp_resolution", 100e-18);
   TimeDelta::initStamps(100);
 
   sprockit::SimParameters::ptr top_params = params->getNamespace("topology");

--- a/sstmac/main/parseopts.cc
+++ b/sstmac/main/parseopts.cc
@@ -98,7 +98,7 @@ parseOpts(int argc, char **argv, opts &oo)
   int lowrestimer = 0;
   int run_ping_all = 0;
   int infinite_network = 0;
-  int outputXYZ = 0;
+  // TODOWARNING int outputXYZ = 0;
   bool need_config_file = true;
   bool machine_configured = false;
   int app_exe_num = 1;

--- a/sstmac/main/sstmac.cc
+++ b/sstmac/main/sstmac.cc
@@ -280,6 +280,7 @@ run(opts& oo,
 #endif
 }
 
+#if 0 // TODOWARNING
 static void tokenize(const std::string& in, std::set<std::string>& tokens){
   std::stringstream sstr(in);
   std::string item;
@@ -287,6 +288,7 @@ static void tokenize(const std::string& in, std::set<std::string>& tokens){
     tokens.insert(item);
   }
 }
+#endif
 
 int
 tryMain(sprockit::SimParameters::ptr params,

--- a/sstmac/main/sstmac.cc
+++ b/sstmac/main/sstmac.cc
@@ -93,7 +93,7 @@ class RuntimeParamBcaster :
  public:
   RuntimeParamBcaster(ParallelRuntime* rt) : rt_(rt) {}
 
-  void bcast(void *buf, int size, int me, int root){
+  void bcast(void *buf, int size, int  /*me*/, int root){
     rt_->bcast(buf, size, root);
   }
 
@@ -169,7 +169,7 @@ initOpts(opts& oo, int argc, char** argv)
  * @param params  An already allocated parameter object
  */
 void
-initParams(ParallelRuntime* rt, opts& oo, sprockit::SimParameters::ptr params, bool parallel)
+initParams(ParallelRuntime* rt, opts& oo, sprockit::SimParameters::ptr params, bool  /*parallel*/)
 {
   //use the config file to set up file search paths
   size_t pos = oo.configfile.find_last_of('/');

--- a/sstmac/main/util.cc
+++ b/sstmac/main/util.cc
@@ -217,7 +217,7 @@ userSkeletonMainInitFxn(const char* name, main_fxn fxn)
   return 42;
 }
 
-static empty_main_fxn empty_skeleton_main;
+// TODOWARNING static empty_main_fxn empty_skeleton_main;
 
 int
 userSkeletonMainInitFxn(const char* name, empty_main_fxn fxn)

--- a/sstmac/main/util.cc
+++ b/sstmac/main/util.cc
@@ -152,20 +152,20 @@ extern "C" void sstmac_exit(int code)
   sstmac::sw::OperatingSystem::currentThread()->kill(code);
 }
 
-extern "C" unsigned int sstmac_alarm(unsigned int delay)
+extern "C" unsigned int sstmac_alarm(unsigned int  /*delay*/)
 {
   //for now, do nothing
   //seriously, why are you using the alarm function?
   return 0;
 }
 
-extern "C" int sstmac_on_exit(void(*fxn)(int,void*), void* arg)
+extern "C" int sstmac_on_exit(void(* /*fxn*/)(int,void*), void*  /*arg*/)
 {
   //for now, just ignore any atexit functions
   return 0;
 }
 
-extern "C" int sstmac_atexit(void (*fxn)(void))
+extern "C" int sstmac_atexit(void (* /*fxn*/)(void))
 {
   //for now, just ignore any atexit functions
   return 0;

--- a/sstmac/skeleton_tls.h
+++ b/sstmac/skeleton_tls.h
@@ -47,6 +47,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include <sstmac/common/sstmac_config.h>
 #include <sstmac/software/process/tls.h>
+#include <unusedvariablemacro.h>
 
 #ifndef SSTMAC_INLINE
 #ifdef __STRICT_ANSI__
@@ -69,6 +70,7 @@ void allocate_static_init_tls_segment();
 }
 #endif
 
+SSTMAC_MAYBE_UNUSED
 static SSTMAC_INLINE char* get_sstmac_global_data(){
   if (sstmac_global_stacksize == 0){
     if (static_init_glbls_segment == 0){
@@ -81,6 +83,7 @@ static SSTMAC_INLINE char* get_sstmac_global_data(){
   }
 }
 
+SSTMAC_MAYBE_UNUSED
 static SSTMAC_INLINE char* get_sstmac_tls_data(){
   if (sstmac_global_stacksize == 0){
     if (static_init_tls_segment == 0){
@@ -93,6 +96,7 @@ static SSTMAC_INLINE char* get_sstmac_tls_data(){
   }
 }
 
+SSTMAC_MAYBE_UNUSED
 static SSTMAC_INLINE int get_sstmac_tls_thread_id(){
   int* idPtr = (int*)(get_sstmac_tls() + SSTMAC_TLS_THREAD_ID);
   return *idPtr;

--- a/sstmac/skeletons/traffic_matrix/main.cc
+++ b/sstmac/skeletons/traffic_matrix/main.cc
@@ -69,11 +69,14 @@ static const int RecvCQ = 0;
 class sumi_param_bcaster : public sprockit::ParamBcaster
 {
  public:
-  sumi_param_bcaster(sumi::CollectiveEngine* engine) : engine_(engine), tag_(12345) {}
+  sumi_param_bcaster(sumi::CollectiveEngine* engine) : 
+    tag_(12345),
+    engine_(engine)
+  {}
 
   void bcast(void *buf, int size, int me, int root){
     engine_->bcast(root, buf, size, sizeof(char), tag_, sumi::Message::default_cq);
-    sumi::CollectiveDoneMessage* msg = nullptr;
+    // TODOWARNING sumi::CollectiveDoneMessage* msg = nullptr;
     auto* dmsg = engine_->blockUntilNext(sumi::Message::default_cq);
     delete dmsg;
     ++tag_;

--- a/sstmac/skeletons/traffic_matrix/main.cc
+++ b/sstmac/skeletons/traffic_matrix/main.cc
@@ -74,7 +74,7 @@ class sumi_param_bcaster : public sprockit::ParamBcaster
     engine_(engine)
   {}
 
-  void bcast(void *buf, int size, int me, int root){
+  void bcast(void *buf, int size, int  /*me*/, int root){
     engine_->bcast(root, buf, size, sizeof(char), tag_, sumi::Message::default_cq);
     // TODOWARNING sumi::CollectiveDoneMessage* msg = nullptr;
     auto* dmsg = engine_->blockUntilNext(sumi::Message::default_cq);
@@ -240,7 +240,7 @@ quiesce(sumi::Transport* tport,
   }
 }
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
   sumi::Transport* tport = sumi::Transport::get();
 

--- a/sstmac/skeletons/undumpi/parsedumpi_callbacks.cc
+++ b/sstmac/skeletons/undumpi/parsedumpi_callbacks.cc
@@ -212,7 +212,7 @@ inline sstmac::TimeDelta deltat(const dumpi_clock &left, const dumpi_clock &righ
 
 /// Indicate that we are starting an MPI call.
 void ParsedumpiCallbacks::
-start_mpi(const dumpi_time *cpu, const dumpi_time *wall,
+start_mpi(const dumpi_time * /*cpu*/, const dumpi_time *wall,
           const dumpi_perfinfo *perf)
 {
   if (!initialized_) return;
@@ -241,7 +241,7 @@ start_mpi(const dumpi_time *cpu, const dumpi_time *wall,
 
 /// Indicate that we have completed an MPI call.
 void ParsedumpiCallbacks::
-end_mpi(const dumpi_time *cpu, const dumpi_time *wall,
+end_mpi(const dumpi_time * /*cpu*/, const dumpi_time *wall,
         const dumpi_perfinfo *perf)
 {
   trace_compute_start_ = wall->stop;
@@ -675,7 +675,7 @@ on_MPI_Rsend(const dumpi_rsend *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Send(const dumpi_send *prm, uint16_t thread,
+on_MPI_Send(const dumpi_send *prm, uint16_t  /*thread*/,
             const dumpi_time *cpu, const dumpi_time *wall,
             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -695,7 +695,7 @@ on_MPI_Send(const dumpi_send *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Recv(const dumpi_recv *prm, uint16_t thread,
+on_MPI_Recv(const dumpi_recv *prm, uint16_t  /*thread*/,
             const dumpi_time *cpu, const dumpi_time *wall,
             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -715,7 +715,7 @@ on_MPI_Recv(const dumpi_recv *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Get_count(const dumpi_get_count *prm, uint16_t thread,
+on_MPI_Get_count(const dumpi_get_count * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -723,7 +723,7 @@ on_MPI_Get_count(const dumpi_get_count *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Buffer_attach(const dumpi_buffer_attach *prm, uint16_t thread,
+on_MPI_Buffer_attach(const dumpi_buffer_attach * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -731,7 +731,7 @@ on_MPI_Buffer_attach(const dumpi_buffer_attach *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Buffer_detach(const dumpi_buffer_detach *prm, uint16_t thread,
+on_MPI_Buffer_detach(const dumpi_buffer_detach * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -766,7 +766,7 @@ on_MPI_Ibsend(const dumpi_ibsend *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Isend(const dumpi_isend *prm, uint16_t thread,
+on_MPI_Isend(const dumpi_isend *prm, uint16_t  /*thread*/,
              const dumpi_time *cpu, const dumpi_time *wall,
              const dumpi_perfinfo *perf, void *uarg)
 {
@@ -786,7 +786,7 @@ on_MPI_Isend(const dumpi_isend *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Irecv(const dumpi_irecv *prm, uint16_t thread,
+on_MPI_Irecv(const dumpi_irecv *prm, uint16_t  /*thread*/,
              const dumpi_time *cpu, const dumpi_time *wall,
              const dumpi_perfinfo *perf, void *uarg)
 {
@@ -806,7 +806,7 @@ on_MPI_Irecv(const dumpi_irecv *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Wait(const dumpi_wait *prm, uint16_t thread,
+on_MPI_Wait(const dumpi_wait *prm, uint16_t  /*thread*/,
             const dumpi_time *cpu, const dumpi_time *wall,
             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -824,7 +824,7 @@ on_MPI_Wait(const dumpi_wait *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Test(const dumpi_test *prm, uint16_t thread,
+on_MPI_Test(const dumpi_test *prm, uint16_t  /*thread*/,
             const dumpi_time *cpu, const dumpi_time *wall,
             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -846,7 +846,7 @@ on_MPI_Test(const dumpi_test *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Request_free(const dumpi_request_free *prm, uint16_t thread,
+on_MPI_Request_free(const dumpi_request_free * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -866,7 +866,7 @@ on_MPI_Waitany(const dumpi_waitany *prm, uint16_t thread,
 // Variant implementation of MPI_Waitany:  pessimistic wait.
 //
 int ParsedumpiCallbacks::
-waitany_pessimistic(const dumpi_waitany *prm, uint16_t thread,
+waitany_pessimistic(const dumpi_waitany *prm, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -899,7 +899,7 @@ on_MPI_Testany(const dumpi_testany *prm, uint16_t thread,
 // Pessimistic remapping of testany calls.
 //
 int ParsedumpiCallbacks::
-testany_pessimistic(const dumpi_testany *prm, uint16_t thread,
+testany_pessimistic(const dumpi_testany *prm, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -921,7 +921,7 @@ testany_pessimistic(const dumpi_testany *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Waitall(const dumpi_waitall *prm, uint16_t thread,
+on_MPI_Waitall(const dumpi_waitall *prm, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -941,7 +941,7 @@ on_MPI_Waitall(const dumpi_waitall *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Testall(const dumpi_testall *prm, uint16_t thread,
+on_MPI_Testall(const dumpi_testall *prm, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -964,7 +964,7 @@ on_MPI_Testall(const dumpi_testall *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Waitsome(const dumpi_waitsome *prm, uint16_t thread,
+on_MPI_Waitsome(const dumpi_waitsome *prm, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -985,7 +985,7 @@ on_MPI_Waitsome(const dumpi_waitsome *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Testsome(const dumpi_testsome *prm, uint16_t thread,
+on_MPI_Testsome(const dumpi_testsome *prm, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1006,7 +1006,7 @@ on_MPI_Testsome(const dumpi_testsome *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Iprobe(const dumpi_iprobe *prm, uint16_t thread,
+on_MPI_Iprobe(const dumpi_iprobe * /*prm*/, uint16_t  /*thread*/,
               const dumpi_time *cpu, const dumpi_time *wall,
               const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1021,7 +1021,7 @@ on_MPI_Iprobe(const dumpi_iprobe *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Probe(const dumpi_probe *prm, uint16_t thread,
+on_MPI_Probe(const dumpi_probe *prm, uint16_t  /*thread*/,
              const dumpi_time *cpu, const dumpi_time *wall,
              const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1040,23 +1040,23 @@ on_MPI_Probe(const dumpi_probe *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cancel(const dumpi_cancel *prm, uint16_t thread,
-              const dumpi_time *cpu, const dumpi_time *wall,
-              const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Cancel(const dumpi_cancel * /*prm*/, uint16_t  /*thread*/,
+              const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+              const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Cancel");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Test_cancelled(const dumpi_test_cancelled *prm, uint16_t thread,
-                      const dumpi_time *cpu, const dumpi_time *wall,
-                      const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Test_cancelled(const dumpi_test_cancelled * /*prm*/, uint16_t  /*thread*/,
+                      const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                      const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Test_cancelled");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Send_init(const dumpi_send_init *prm, uint16_t thread,
+on_MPI_Send_init(const dumpi_send_init *prm, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1101,7 +1101,7 @@ on_MPI_Ssend_init(const dumpi_ssend_init *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Recv_init(const dumpi_recv_init *prm, uint16_t thread,
+on_MPI_Recv_init(const dumpi_recv_init *prm, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1120,7 +1120,7 @@ on_MPI_Recv_init(const dumpi_recv_init *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Start(const dumpi_start *prm, uint16_t thread,
+on_MPI_Start(const dumpi_start *prm, uint16_t  /*thread*/,
              const dumpi_time *cpu, const dumpi_time *wall,
              const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1138,7 +1138,7 @@ on_MPI_Start(const dumpi_start *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Startall(const dumpi_startall *prm, uint16_t thread,
+on_MPI_Startall(const dumpi_startall *prm, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1155,7 +1155,7 @@ on_MPI_Startall(const dumpi_startall *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Sendrecv(const dumpi_sendrecv *prm, uint16_t thread,
+on_MPI_Sendrecv(const dumpi_sendrecv *prm, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1177,7 +1177,7 @@ on_MPI_Sendrecv(const dumpi_sendrecv *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Sendrecv_replace(const dumpi_sendrecv_replace *prm, uint16_t thread,
+on_MPI_Sendrecv_replace(const dumpi_sendrecv_replace *prm, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1199,7 +1199,7 @@ on_MPI_Sendrecv_replace(const dumpi_sendrecv_replace *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_contiguous(const dumpi_type_contiguous *prm, uint16_t thread,
+on_MPI_Type_contiguous(const dumpi_type_contiguous *prm, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1218,7 +1218,7 @@ on_MPI_Type_contiguous(const dumpi_type_contiguous *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_vector(const dumpi_type_vector *prm, uint16_t thread,
+on_MPI_Type_vector(const dumpi_type_vector *prm, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1238,15 +1238,15 @@ on_MPI_Type_vector(const dumpi_type_vector *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_hvector(const dumpi_type_hvector *prm, uint16_t thread,
-                    const dumpi_time *cpu, const dumpi_time *wall,
-                    const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Type_hvector(const dumpi_type_hvector * /*prm*/, uint16_t  /*thread*/,
+                    const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                    const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_hvector");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_indexed(const dumpi_type_indexed *prm, uint16_t thread,
+on_MPI_Type_indexed(const dumpi_type_indexed *prm, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1266,15 +1266,15 @@ on_MPI_Type_indexed(const dumpi_type_indexed *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_hindexed(const dumpi_type_hindexed *prm, uint16_t thread,
-                     const dumpi_time *cpu, const dumpi_time *wall,
-                     const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Type_hindexed(const dumpi_type_hindexed * /*prm*/, uint16_t  /*thread*/,
+                     const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                     const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_hindexed");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_struct(const dumpi_type_struct *prm, uint16_t thread,
+on_MPI_Type_struct(const dumpi_type_struct *prm, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1292,7 +1292,7 @@ on_MPI_Type_struct(const dumpi_type_struct *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Address(const dumpi_address *prm, uint16_t thread,
+on_MPI_Address(const dumpi_address * /*prm*/, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1300,7 +1300,7 @@ on_MPI_Address(const dumpi_address *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_extent(const dumpi_type_extent *prm, uint16_t thread,
+on_MPI_Type_extent(const dumpi_type_extent * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1308,7 +1308,7 @@ on_MPI_Type_extent(const dumpi_type_extent *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_size(const dumpi_type_size *prm, uint16_t thread,
+on_MPI_Type_size(const dumpi_type_size * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1316,7 +1316,7 @@ on_MPI_Type_size(const dumpi_type_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_lb(const dumpi_type_lb *prm, uint16_t thread,
+on_MPI_Type_lb(const dumpi_type_lb * /*prm*/, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1324,7 +1324,7 @@ on_MPI_Type_lb(const dumpi_type_lb *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_ub(const dumpi_type_ub *prm, uint16_t thread,
+on_MPI_Type_ub(const dumpi_type_ub * /*prm*/, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1332,7 +1332,7 @@ on_MPI_Type_ub(const dumpi_type_ub *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_commit(const dumpi_type_commit *prm, uint16_t thread,
+on_MPI_Type_commit(const dumpi_type_commit *prm, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1348,7 +1348,7 @@ on_MPI_Type_commit(const dumpi_type_commit *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_free(const dumpi_type_free *prm, uint16_t thread,
+on_MPI_Type_free(const dumpi_type_free *prm, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1364,7 +1364,7 @@ on_MPI_Type_free(const dumpi_type_free *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Get_elements(const dumpi_get_elements *prm, uint16_t thread,
+on_MPI_Get_elements(const dumpi_get_elements * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1372,7 +1372,7 @@ on_MPI_Get_elements(const dumpi_get_elements *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Pack(const dumpi_pack *prm, uint16_t thread,
+on_MPI_Pack(const dumpi_pack * /*prm*/, uint16_t  /*thread*/,
             const dumpi_time *cpu, const dumpi_time *wall,
             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1380,7 +1380,7 @@ on_MPI_Pack(const dumpi_pack *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Unpack(const dumpi_unpack *prm, uint16_t thread,
+on_MPI_Unpack(const dumpi_unpack * /*prm*/, uint16_t  /*thread*/,
               const dumpi_time *cpu, const dumpi_time *wall,
               const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1388,7 +1388,7 @@ on_MPI_Unpack(const dumpi_unpack *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Pack_size(const dumpi_pack_size *prm, uint16_t thread,
+on_MPI_Pack_size(const dumpi_pack_size * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1396,7 +1396,7 @@ on_MPI_Pack_size(const dumpi_pack_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Barrier(const dumpi_barrier *prm, uint16_t thread,
+on_MPI_Barrier(const dumpi_barrier *prm, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1414,7 +1414,7 @@ on_MPI_Barrier(const dumpi_barrier *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Bcast(const dumpi_bcast *prm, uint16_t thread,
+on_MPI_Bcast(const dumpi_bcast *prm, uint16_t  /*thread*/,
              const dumpi_time *cpu, const dumpi_time *wall,
              const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1433,7 +1433,7 @@ on_MPI_Bcast(const dumpi_bcast *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Gather(const dumpi_gather *prm, uint16_t thread,
+on_MPI_Gather(const dumpi_gather *prm, uint16_t  /*thread*/,
               const dumpi_time *cpu, const dumpi_time *wall,
               const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1456,7 +1456,7 @@ on_MPI_Gather(const dumpi_gather *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Gatherv(const dumpi_gatherv *prm, uint16_t thread,
+on_MPI_Gatherv(const dumpi_gatherv *prm, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1490,7 +1490,7 @@ on_MPI_Gatherv(const dumpi_gatherv *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Scatter(const dumpi_scatter *prm, uint16_t thread,
+on_MPI_Scatter(const dumpi_scatter *prm, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1513,7 +1513,7 @@ on_MPI_Scatter(const dumpi_scatter *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Scatterv(const dumpi_scatterv *prm, uint16_t thread,
+on_MPI_Scatterv(const dumpi_scatterv *prm, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1536,7 +1536,7 @@ on_MPI_Scatterv(const dumpi_scatterv *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Allgather(const dumpi_allgather *prm, uint16_t thread,
+on_MPI_Allgather(const dumpi_allgather *prm, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1558,7 +1558,7 @@ on_MPI_Allgather(const dumpi_allgather *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Allgatherv(const dumpi_allgatherv *prm, uint16_t thread,
+on_MPI_Allgatherv(const dumpi_allgatherv *prm, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1580,7 +1580,7 @@ on_MPI_Allgatherv(const dumpi_allgatherv *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Alltoall(const dumpi_alltoall *prm, uint16_t thread,
+on_MPI_Alltoall(const dumpi_alltoall *prm, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1602,7 +1602,7 @@ on_MPI_Alltoall(const dumpi_alltoall *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Alltoallv(const dumpi_alltoallv *prm, uint16_t thread,
+on_MPI_Alltoallv(const dumpi_alltoallv *prm, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1622,7 +1622,7 @@ on_MPI_Alltoallv(const dumpi_alltoallv *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Reduce(const dumpi_reduce *prm, uint16_t thread,
+on_MPI_Reduce(const dumpi_reduce *prm, uint16_t  /*thread*/,
               const dumpi_time *cpu, const dumpi_time *wall,
               const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1643,7 +1643,7 @@ on_MPI_Reduce(const dumpi_reduce *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Allreduce(const dumpi_allreduce *prm, uint16_t thread,
+on_MPI_Allreduce(const dumpi_allreduce *prm, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1664,7 +1664,7 @@ on_MPI_Allreduce(const dumpi_allreduce *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Reduce_scatter(const dumpi_reduce_scatter *prm, uint16_t thread,
+on_MPI_Reduce_scatter(const dumpi_reduce_scatter *prm, uint16_t  /*thread*/,
                       const dumpi_time *cpu, const dumpi_time *wall,
                       const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1683,7 +1683,7 @@ on_MPI_Reduce_scatter(const dumpi_reduce_scatter *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Scan(const dumpi_scan *prm, uint16_t thread,
+on_MPI_Scan(const dumpi_scan *prm, uint16_t  /*thread*/,
             const dumpi_time *cpu, const dumpi_time *wall,
             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1700,7 +1700,7 @@ on_MPI_Scan(const dumpi_scan *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Op_create(const dumpi_op_create *prm, uint16_t thread,
+on_MPI_Op_create(const dumpi_op_create * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1708,7 +1708,7 @@ on_MPI_Op_create(const dumpi_op_create *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Op_free(const dumpi_op_free *prm, uint16_t thread,
+on_MPI_Op_free(const dumpi_op_free * /*prm*/, uint16_t  /*thread*/,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1716,7 +1716,7 @@ on_MPI_Op_free(const dumpi_op_free *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_size(const dumpi_group_size *prm, uint16_t thread,
+on_MPI_Group_size(const dumpi_group_size * /*prm*/, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1724,7 +1724,7 @@ on_MPI_Group_size(const dumpi_group_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_rank(const dumpi_group_rank *prm, uint16_t thread,
+on_MPI_Group_rank(const dumpi_group_rank * /*prm*/, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1732,8 +1732,8 @@ on_MPI_Group_rank(const dumpi_group_rank *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_translate_ranks(const dumpi_group_translate_ranks *prm,
-                             uint16_t thread,
+on_MPI_Group_translate_ranks(const dumpi_group_translate_ranks * /*prm*/,
+                             uint16_t  /*thread*/,
                              const dumpi_time *cpu, const dumpi_time *wall,
                              const dumpi_perfinfo *perf, void*uarg)
 {
@@ -1741,7 +1741,7 @@ on_MPI_Group_translate_ranks(const dumpi_group_translate_ranks *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_compare(const dumpi_group_compare *prm, uint16_t thread,
+on_MPI_Group_compare(const dumpi_group_compare * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1749,7 +1749,7 @@ on_MPI_Group_compare(const dumpi_group_compare *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_group(const dumpi_comm_group *prm, uint16_t thread,
+on_MPI_Comm_group(const dumpi_comm_group * /*prm*/, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1757,7 +1757,7 @@ on_MPI_Comm_group(const dumpi_comm_group *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_union(const dumpi_group_union *prm, uint16_t thread,
+on_MPI_Group_union(const dumpi_group_union * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1765,7 +1765,7 @@ on_MPI_Group_union(const dumpi_group_union *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_intersection(const dumpi_group_intersection *prm, uint16_t thread,
+on_MPI_Group_intersection(const dumpi_group_intersection * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1773,7 +1773,7 @@ on_MPI_Group_intersection(const dumpi_group_intersection *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_difference(const dumpi_group_difference *prm, uint16_t thread,
+on_MPI_Group_difference(const dumpi_group_difference * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1781,7 +1781,7 @@ on_MPI_Group_difference(const dumpi_group_difference *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_incl(const dumpi_group_incl *prm, uint16_t thread,
+on_MPI_Group_incl(const dumpi_group_incl *prm, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1802,7 +1802,7 @@ on_MPI_Group_incl(const dumpi_group_incl *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_excl(const dumpi_group_excl *prm, uint16_t thread,
+on_MPI_Group_excl(const dumpi_group_excl * /*prm*/, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1810,7 +1810,7 @@ on_MPI_Group_excl(const dumpi_group_excl *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_range_incl(const dumpi_group_range_incl *prm, uint16_t thread,
+on_MPI_Group_range_incl(const dumpi_group_range_incl * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1818,7 +1818,7 @@ on_MPI_Group_range_incl(const dumpi_group_range_incl *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_range_excl(const dumpi_group_range_excl *prm, uint16_t thread,
+on_MPI_Group_range_excl(const dumpi_group_range_excl * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1826,7 +1826,7 @@ on_MPI_Group_range_excl(const dumpi_group_range_excl *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Group_free(const dumpi_group_free *prm, uint16_t thread,
+on_MPI_Group_free(const dumpi_group_free * /*prm*/, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1834,7 +1834,7 @@ on_MPI_Group_free(const dumpi_group_free *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_size(const dumpi_comm_size *prm, uint16_t thread,
+on_MPI_Comm_size(const dumpi_comm_size * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1842,7 +1842,7 @@ on_MPI_Comm_size(const dumpi_comm_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_rank(const dumpi_comm_rank *prm, uint16_t thread,
+on_MPI_Comm_rank(const dumpi_comm_rank * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1850,7 +1850,7 @@ on_MPI_Comm_rank(const dumpi_comm_rank *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_compare(const dumpi_comm_compare *prm, uint16_t thread,
+on_MPI_Comm_compare(const dumpi_comm_compare * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1858,7 +1858,7 @@ on_MPI_Comm_compare(const dumpi_comm_compare *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_dup(const dumpi_comm_dup *prm, uint16_t thread,
+on_MPI_Comm_dup(const dumpi_comm_dup *prm, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1876,7 +1876,7 @@ on_MPI_Comm_dup(const dumpi_comm_dup *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_create(const dumpi_comm_create *prm, uint16_t thread,
+on_MPI_Comm_create(const dumpi_comm_create *prm, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1895,7 +1895,7 @@ on_MPI_Comm_create(const dumpi_comm_create *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_split(const dumpi_comm_split *prm, uint16_t thread,
+on_MPI_Comm_split(const dumpi_comm_split *prm, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1914,7 +1914,7 @@ on_MPI_Comm_split(const dumpi_comm_split *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_free(const dumpi_comm_free *prm, uint16_t thread,
+on_MPI_Comm_free(const dumpi_comm_free *prm, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1933,7 +1933,7 @@ on_MPI_Comm_free(const dumpi_comm_free *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_test_inter(const dumpi_comm_test_inter *prm, uint16_t thread,
+on_MPI_Comm_test_inter(const dumpi_comm_test_inter * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1941,7 +1941,7 @@ on_MPI_Comm_test_inter(const dumpi_comm_test_inter *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_remote_size(const dumpi_comm_remote_size *prm, uint16_t thread,
+on_MPI_Comm_remote_size(const dumpi_comm_remote_size * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1949,7 +1949,7 @@ on_MPI_Comm_remote_size(const dumpi_comm_remote_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_remote_group(const dumpi_comm_remote_group *prm, uint16_t thread,
+on_MPI_Comm_remote_group(const dumpi_comm_remote_group * /*prm*/, uint16_t  /*thread*/,
                          const dumpi_time *cpu, const dumpi_time *wall,
                          const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1957,7 +1957,7 @@ on_MPI_Comm_remote_group(const dumpi_comm_remote_group *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Intercomm_create(const dumpi_intercomm_create *prm, uint16_t thread,
+on_MPI_Intercomm_create(const dumpi_intercomm_create * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1965,7 +1965,7 @@ on_MPI_Intercomm_create(const dumpi_intercomm_create *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Intercomm_merge(const dumpi_intercomm_merge *prm, uint16_t thread,
+on_MPI_Intercomm_merge(const dumpi_intercomm_merge * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1973,7 +1973,7 @@ on_MPI_Intercomm_merge(const dumpi_intercomm_merge *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Keyval_create(const dumpi_keyval_create *prm, uint16_t thread,
+on_MPI_Keyval_create(const dumpi_keyval_create * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1981,7 +1981,7 @@ on_MPI_Keyval_create(const dumpi_keyval_create *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Keyval_free(const dumpi_keyval_free *prm, uint16_t thread,
+on_MPI_Keyval_free(const dumpi_keyval_free * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1989,7 +1989,7 @@ on_MPI_Keyval_free(const dumpi_keyval_free *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Attr_put(const dumpi_attr_put *prm, uint16_t thread,
+on_MPI_Attr_put(const dumpi_attr_put * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -1997,7 +1997,7 @@ on_MPI_Attr_put(const dumpi_attr_put *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Attr_get(const dumpi_attr_get *prm, uint16_t thread,
+on_MPI_Attr_get(const dumpi_attr_get * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2005,7 +2005,7 @@ on_MPI_Attr_get(const dumpi_attr_get *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Attr_delete(const dumpi_attr_delete *prm, uint16_t thread,
+on_MPI_Attr_delete(const dumpi_attr_delete * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2013,7 +2013,7 @@ on_MPI_Attr_delete(const dumpi_attr_delete *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Topo_test(const dumpi_topo_test *prm, uint16_t thread,
+on_MPI_Topo_test(const dumpi_topo_test * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2021,15 +2021,15 @@ on_MPI_Topo_test(const dumpi_topo_test *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cart_create(const dumpi_cart_create *prm, uint16_t thread,
-                   const dumpi_time *cpu, const dumpi_time *wall,
-                   const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Cart_create(const dumpi_cart_create * /*prm*/, uint16_t  /*thread*/,
+                   const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                   const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("MPI_Cart_create");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Dims_create(const dumpi_dims_create *prm, uint16_t thread,
+on_MPI_Dims_create(const dumpi_dims_create * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2037,7 +2037,7 @@ on_MPI_Dims_create(const dumpi_dims_create *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Graph_create(const dumpi_graph_create *prm, uint16_t thread,
+on_MPI_Graph_create(const dumpi_graph_create * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2045,7 +2045,7 @@ on_MPI_Graph_create(const dumpi_graph_create *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Graphdims_get(const dumpi_graphdims_get *prm, uint16_t thread,
+on_MPI_Graphdims_get(const dumpi_graphdims_get * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2053,7 +2053,7 @@ on_MPI_Graphdims_get(const dumpi_graphdims_get *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Graph_get(const dumpi_graph_get *prm, uint16_t thread,
+on_MPI_Graph_get(const dumpi_graph_get * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2061,7 +2061,7 @@ on_MPI_Graph_get(const dumpi_graph_get *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cartdim_get(const dumpi_cartdim_get *prm, uint16_t thread,
+on_MPI_Cartdim_get(const dumpi_cartdim_get * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2069,7 +2069,7 @@ on_MPI_Cartdim_get(const dumpi_cartdim_get *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cart_get(const dumpi_cart_get *prm, uint16_t thread,
+on_MPI_Cart_get(const dumpi_cart_get * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2077,7 +2077,7 @@ on_MPI_Cart_get(const dumpi_cart_get *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cart_rank(const dumpi_cart_rank *prm, uint16_t thread,
+on_MPI_Cart_rank(const dumpi_cart_rank * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2085,7 +2085,7 @@ on_MPI_Cart_rank(const dumpi_cart_rank *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cart_coords(const dumpi_cart_coords *prm, uint16_t thread,
+on_MPI_Cart_coords(const dumpi_cart_coords * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2093,8 +2093,8 @@ on_MPI_Cart_coords(const dumpi_cart_coords *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Graph_neighbors_count(const dumpi_graph_neighbors_count *prm,
-                             uint16_t thread,
+on_MPI_Graph_neighbors_count(const dumpi_graph_neighbors_count * /*prm*/,
+                             uint16_t  /*thread*/,
                              const dumpi_time *cpu, const dumpi_time *wall,
                              const dumpi_perfinfo *perf,void *uarg)
 {
@@ -2102,7 +2102,7 @@ on_MPI_Graph_neighbors_count(const dumpi_graph_neighbors_count *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Graph_neighbors(const dumpi_graph_neighbors *prm, uint16_t thread,
+on_MPI_Graph_neighbors(const dumpi_graph_neighbors * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2110,7 +2110,7 @@ on_MPI_Graph_neighbors(const dumpi_graph_neighbors *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cart_shift(const dumpi_cart_shift *prm, uint16_t thread,
+on_MPI_Cart_shift(const dumpi_cart_shift * /*prm*/, uint16_t  /*thread*/,
                   const dumpi_time *cpu, const dumpi_time *wall,
                   const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2118,7 +2118,7 @@ on_MPI_Cart_shift(const dumpi_cart_shift *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cart_sub(const dumpi_cart_sub *prm, uint16_t thread,
+on_MPI_Cart_sub(const dumpi_cart_sub * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2126,7 +2126,7 @@ on_MPI_Cart_sub(const dumpi_cart_sub *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Cart_map(const dumpi_cart_map *prm, uint16_t thread,
+on_MPI_Cart_map(const dumpi_cart_map * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2134,7 +2134,7 @@ on_MPI_Cart_map(const dumpi_cart_map *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Graph_map(const dumpi_graph_map *prm, uint16_t thread,
+on_MPI_Graph_map(const dumpi_graph_map * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2142,7 +2142,7 @@ on_MPI_Graph_map(const dumpi_graph_map *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Get_processor_name(const dumpi_get_processor_name *prm, uint16_t thread,
+on_MPI_Get_processor_name(const dumpi_get_processor_name * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2150,7 +2150,7 @@ on_MPI_Get_processor_name(const dumpi_get_processor_name *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Get_version(const dumpi_get_version *prm, uint16_t thread,
+on_MPI_Get_version(const dumpi_get_version * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2158,7 +2158,7 @@ on_MPI_Get_version(const dumpi_get_version *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Errhandler_create(const dumpi_errhandler_create *prm, uint16_t thread,
+on_MPI_Errhandler_create(const dumpi_errhandler_create * /*prm*/, uint16_t  /*thread*/,
                          const dumpi_time *cpu, const dumpi_time *wall,
                          const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2166,7 +2166,7 @@ on_MPI_Errhandler_create(const dumpi_errhandler_create *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Errhandler_set(const dumpi_errhandler_set *prm, uint16_t thread,
+on_MPI_Errhandler_set(const dumpi_errhandler_set * /*prm*/, uint16_t  /*thread*/,
                       const dumpi_time *cpu, const dumpi_time *wall,
                       const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2174,7 +2174,7 @@ on_MPI_Errhandler_set(const dumpi_errhandler_set *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Errhandler_get(const dumpi_errhandler_get *prm, uint16_t thread,
+on_MPI_Errhandler_get(const dumpi_errhandler_get * /*prm*/, uint16_t  /*thread*/,
                       const dumpi_time *cpu, const dumpi_time *wall,
                       const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2182,7 +2182,7 @@ on_MPI_Errhandler_get(const dumpi_errhandler_get *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Errhandler_free(const dumpi_errhandler_free *prm, uint16_t thread,
+on_MPI_Errhandler_free(const dumpi_errhandler_free * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2190,7 +2190,7 @@ on_MPI_Errhandler_free(const dumpi_errhandler_free *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Error_string(const dumpi_error_string *prm, uint16_t thread,
+on_MPI_Error_string(const dumpi_error_string * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2198,7 +2198,7 @@ on_MPI_Error_string(const dumpi_error_string *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Error_class(const dumpi_error_class *prm, uint16_t thread,
+on_MPI_Error_class(const dumpi_error_class * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2206,7 +2206,7 @@ on_MPI_Error_class(const dumpi_error_class *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Wtime(const dumpi_wtime *prm, uint16_t thread,
+on_MPI_Wtime(const dumpi_wtime * /*prm*/, uint16_t  /*thread*/,
              const dumpi_time *cpu, const dumpi_time *wall,
              const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2214,7 +2214,7 @@ on_MPI_Wtime(const dumpi_wtime *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Wtick(const dumpi_wtick *prm, uint16_t thread,
+on_MPI_Wtick(const dumpi_wtick * /*prm*/, uint16_t  /*thread*/,
              const dumpi_time *cpu, const dumpi_time *wall,
              const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2222,7 +2222,7 @@ on_MPI_Wtick(const dumpi_wtick *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_dup(const dumpi_type_dup *prm, uint16_t thread,
+on_MPI_Type_dup(const dumpi_type_dup *prm, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2239,7 +2239,7 @@ on_MPI_Type_dup(const dumpi_type_dup *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Init(const dumpi_init *prm, uint16_t thread,
+on_MPI_Init(const dumpi_init *prm, uint16_t  /*thread*/,
             const dumpi_time *cpu, const dumpi_time *wall,
             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2256,7 +2256,7 @@ on_MPI_Init(const dumpi_init *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Init_thread(const dumpi_init_thread *prm, uint16_t thread,
+on_MPI_Init_thread(const dumpi_init_thread *prm, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2291,7 +2291,7 @@ on_MPI_Init_thread(const dumpi_init_thread *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Finalize(const dumpi_finalize *prm, uint16_t thread,
+on_MPI_Finalize(const dumpi_finalize * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2306,7 +2306,7 @@ on_MPI_Finalize(const dumpi_finalize *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Initialized(const dumpi_initialized *prm, uint16_t thread,
+on_MPI_Initialized(const dumpi_initialized * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2314,7 +2314,7 @@ on_MPI_Initialized(const dumpi_initialized *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Abort(const dumpi_abort *prm, uint16_t thread,
+on_MPI_Abort(const dumpi_abort * /*prm*/, uint16_t  /*thread*/,
              const dumpi_time *cpu, const dumpi_time *wall,
              const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2322,15 +2322,15 @@ on_MPI_Abort(const dumpi_abort *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Close_port(const dumpi_close_port *prm, uint16_t thread,
-                  const dumpi_time *cpu, const dumpi_time *wall,
-                  const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Close_port(const dumpi_close_port * /*prm*/, uint16_t  /*thread*/,
+                  const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                  const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Close_port");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_accept(const dumpi_comm_accept *prm, uint16_t thread,
+on_MPI_Comm_accept(const dumpi_comm_accept * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2338,23 +2338,23 @@ on_MPI_Comm_accept(const dumpi_comm_accept *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_connect(const dumpi_comm_connect *prm, uint16_t thread,
-                    const dumpi_time *cpu, const dumpi_time *wall,
-                    const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Comm_connect(const dumpi_comm_connect * /*prm*/, uint16_t  /*thread*/,
+                    const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                    const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Comm_connect");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_disconnect(const dumpi_comm_disconnect *prm, uint16_t thread,
-                       const dumpi_time *cpu, const dumpi_time *wall,
-                       const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Comm_disconnect(const dumpi_comm_disconnect * /*prm*/, uint16_t  /*thread*/,
+                       const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                       const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Comm_disconnect");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_get_parent(const dumpi_comm_get_parent *prm, uint16_t thread,
+on_MPI_Comm_get_parent(const dumpi_comm_get_parent * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2362,32 +2362,32 @@ on_MPI_Comm_get_parent(const dumpi_comm_get_parent *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_join(const dumpi_comm_join *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Comm_join(const dumpi_comm_join * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Comm_join");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_spawn(const dumpi_comm_spawn *prm, uint16_t thread,
-                  const dumpi_time *cpu, const dumpi_time *wall,
-                  const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Comm_spawn(const dumpi_comm_spawn * /*prm*/, uint16_t  /*thread*/,
+                  const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                  const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Comm_spawn");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_spawn_multiple(const dumpi_comm_spawn_multiple *prm,
-                           uint16_t thread,
-                           const dumpi_time *cpu, const dumpi_time *wall,
-                           const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Comm_spawn_multiple(const dumpi_comm_spawn_multiple * /*prm*/,
+                           uint16_t  /*thread*/,
+                           const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                           const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Comm_spawn_multiple");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Lookup_name(const dumpi_lookup_name *prm, uint16_t thread,
+on_MPI_Lookup_name(const dumpi_lookup_name * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2395,159 +2395,159 @@ on_MPI_Lookup_name(const dumpi_lookup_name *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Open_port(const dumpi_open_port *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Open_port(const dumpi_open_port * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Open_port");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Publish_name(const dumpi_publish_name *prm, uint16_t thread,
-                    const dumpi_time *cpu, const dumpi_time *wall,
-                    const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Publish_name(const dumpi_publish_name * /*prm*/, uint16_t  /*thread*/,
+                    const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                    const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Publish_name");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Unpublish_name(const dumpi_unpublish_name *prm, uint16_t thread,
-                      const dumpi_time *cpu, const dumpi_time *wall,
-                      const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Unpublish_name(const dumpi_unpublish_name * /*prm*/, uint16_t  /*thread*/,
+                      const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                      const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Unpublish_name");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Accumulate(const dumpi_accumulate *prm, uint16_t thread,
-                  const dumpi_time *cpu, const dumpi_time *wall,
-                  const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Accumulate(const dumpi_accumulate * /*prm*/, uint16_t  /*thread*/,
+                  const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                  const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Accumulate");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Get(const dumpi_get *prm, uint16_t thread,
-           const dumpi_time *cpu, const dumpi_time *wall,
-           const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Get(const dumpi_get * /*prm*/, uint16_t  /*thread*/,
+           const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+           const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Get");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Put(const dumpi_put *prm, uint16_t thread,
-           const dumpi_time *cpu, const dumpi_time *wall,
-           const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Put(const dumpi_put * /*prm*/, uint16_t  /*thread*/,
+           const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+           const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Put");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_complete(const dumpi_win_complete *prm, uint16_t thread,
-                    const dumpi_time *cpu, const dumpi_time *wall,
-                    const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_complete(const dumpi_win_complete * /*prm*/, uint16_t  /*thread*/,
+                    const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                    const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_complete");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_create(const dumpi_win_create *prm, uint16_t thread,
-                  const dumpi_time *cpu, const dumpi_time *wall,
-                  const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_create(const dumpi_win_create * /*prm*/, uint16_t  /*thread*/,
+                  const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                  const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_create");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_fence(const dumpi_win_fence *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_fence(const dumpi_win_fence * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_fence");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_free(const dumpi_win_free *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_free(const dumpi_win_free * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_free");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_get_group(const dumpi_win_get_group *prm, uint16_t thread,
-                     const dumpi_time *cpu, const dumpi_time *wall,
-                     const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_get_group(const dumpi_win_get_group * /*prm*/, uint16_t  /*thread*/,
+                     const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                     const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_get_group");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_lock(const dumpi_win_lock *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_lock(const dumpi_win_lock * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_lock");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_post(const dumpi_win_post *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_post(const dumpi_win_post * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_post");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_start(const dumpi_win_start *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_start(const dumpi_win_start * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_start");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_test(const dumpi_win_test *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_test(const dumpi_win_test * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_test");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_unlock(const dumpi_win_unlock *prm, uint16_t thread,
-                  const dumpi_time *cpu, const dumpi_time *wall,
-                  const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_unlock(const dumpi_win_unlock * /*prm*/, uint16_t  /*thread*/,
+                  const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                  const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_unlock");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_wait(const dumpi_win_wait *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Win_wait(const dumpi_win_wait * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Win_wait");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Alltoallw(const dumpi_alltoallw *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Alltoallw(const dumpi_alltoallw * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Alltoallw");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Exscan(const dumpi_exscan *prm, uint16_t thread,
-              const dumpi_time *cpu, const dumpi_time *wall,
-              const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Exscan(const dumpi_exscan * /*prm*/, uint16_t  /*thread*/,
+              const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+              const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Exscan");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Add_error_class(const dumpi_add_error_class *prm, uint16_t thread,
+on_MPI_Add_error_class(const dumpi_add_error_class * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2555,7 +2555,7 @@ on_MPI_Add_error_class(const dumpi_add_error_class *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Add_error_code(const dumpi_add_error_code *prm, uint16_t thread,
+on_MPI_Add_error_code(const dumpi_add_error_code * /*prm*/, uint16_t  /*thread*/,
                       const dumpi_time *cpu, const dumpi_time *wall,
                       const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2563,7 +2563,7 @@ on_MPI_Add_error_code(const dumpi_add_error_code *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Add_error_string(const dumpi_add_error_string *prm, uint16_t thread,
+on_MPI_Add_error_string(const dumpi_add_error_string * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2571,8 +2571,8 @@ on_MPI_Add_error_string(const dumpi_add_error_string *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_call_errhandler(const dumpi_comm_call_errhandler *prm,
-                            uint16_t thread,
+on_MPI_Comm_call_errhandler(const dumpi_comm_call_errhandler * /*prm*/,
+                            uint16_t  /*thread*/,
                             const dumpi_time *cpu, const dumpi_time *wall,
                             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2580,7 +2580,7 @@ on_MPI_Comm_call_errhandler(const dumpi_comm_call_errhandler *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_create_keyval(const dumpi_comm_create_keyval *prm, uint16_t thread,
+on_MPI_Comm_create_keyval(const dumpi_comm_create_keyval * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2588,7 +2588,7 @@ on_MPI_Comm_create_keyval(const dumpi_comm_create_keyval *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_delete_attr(const dumpi_comm_delete_attr *prm, uint16_t thread,
+on_MPI_Comm_delete_attr(const dumpi_comm_delete_attr * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2596,7 +2596,7 @@ on_MPI_Comm_delete_attr(const dumpi_comm_delete_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_free_keyval(const dumpi_comm_free_keyval *prm, uint16_t thread,
+on_MPI_Comm_free_keyval(const dumpi_comm_free_keyval * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2604,7 +2604,7 @@ on_MPI_Comm_free_keyval(const dumpi_comm_free_keyval *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_get_attr(const dumpi_comm_get_attr *prm, uint16_t thread,
+on_MPI_Comm_get_attr(const dumpi_comm_get_attr * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2612,7 +2612,7 @@ on_MPI_Comm_get_attr(const dumpi_comm_get_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_get_name(const dumpi_comm_get_name *prm, uint16_t thread,
+on_MPI_Comm_get_name(const dumpi_comm_get_name * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2620,7 +2620,7 @@ on_MPI_Comm_get_name(const dumpi_comm_get_name *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_set_attr(const dumpi_comm_set_attr *prm, uint16_t thread,
+on_MPI_Comm_set_attr(const dumpi_comm_set_attr * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2628,7 +2628,7 @@ on_MPI_Comm_set_attr(const dumpi_comm_set_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_set_name(const dumpi_comm_set_name *prm, uint16_t thread,
+on_MPI_Comm_set_name(const dumpi_comm_set_name * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2636,8 +2636,8 @@ on_MPI_Comm_set_name(const dumpi_comm_set_name *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_call_errhandler(const dumpi_file_call_errhandler *prm,
-                            uint16_t thread,
+on_MPI_File_call_errhandler(const dumpi_file_call_errhandler * /*prm*/,
+                            uint16_t  /*thread*/,
                             const dumpi_time *cpu, const dumpi_time *wall,
                             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2645,23 +2645,23 @@ on_MPI_File_call_errhandler(const dumpi_file_call_errhandler *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Grequest_complete(const dumpi_grequest_complete *prm, uint16_t thread,
-                         const dumpi_time *cpu, const dumpi_time *wall,
-                         const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Grequest_complete(const dumpi_grequest_complete * /*prm*/, uint16_t  /*thread*/,
+                         const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                         const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Add_error_class");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Grequest_start(const dumpi_grequest_start *prm, uint16_t thread,
-                      const dumpi_time *cpu, const dumpi_time *wall,
-                      const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Grequest_start(const dumpi_grequest_start * /*prm*/, uint16_t  /*thread*/,
+                      const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                      const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Add_error_class");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Is_thread_main(const dumpi_is_thread_main *prm, uint16_t thread,
+on_MPI_Is_thread_main(const dumpi_is_thread_main * /*prm*/, uint16_t  /*thread*/,
                       const dumpi_time *cpu, const dumpi_time *wall,
                       const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2669,7 +2669,7 @@ on_MPI_Is_thread_main(const dumpi_is_thread_main *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Query_thread(const dumpi_query_thread *prm, uint16_t thread,
+on_MPI_Query_thread(const dumpi_query_thread * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2677,8 +2677,8 @@ on_MPI_Query_thread(const dumpi_query_thread *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Status_set_cancelled(const dumpi_status_set_cancelled *prm,
-                            uint16_t thread,
+on_MPI_Status_set_cancelled(const dumpi_status_set_cancelled * /*prm*/,
+                            uint16_t  /*thread*/,
                             const dumpi_time *cpu, const dumpi_time *wall,
                             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2686,8 +2686,8 @@ on_MPI_Status_set_cancelled(const dumpi_status_set_cancelled *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Status_set_elements(const dumpi_status_set_elements *prm,
-                           uint16_t thread,
+on_MPI_Status_set_elements(const dumpi_status_set_elements * /*prm*/,
+                           uint16_t  /*thread*/,
                            const dumpi_time *cpu, const dumpi_time *wall,
                            const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2695,7 +2695,7 @@ on_MPI_Status_set_elements(const dumpi_status_set_elements *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_create_keyval(const dumpi_type_create_keyval *prm, uint16_t thread,
+on_MPI_Type_create_keyval(const dumpi_type_create_keyval * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2703,7 +2703,7 @@ on_MPI_Type_create_keyval(const dumpi_type_create_keyval *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_delete_attr(const dumpi_type_delete_attr *prm, uint16_t thread,
+on_MPI_Type_delete_attr(const dumpi_type_delete_attr * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2711,7 +2711,7 @@ on_MPI_Type_delete_attr(const dumpi_type_delete_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_free_keyval(const dumpi_type_free_keyval *prm, uint16_t thread,
+on_MPI_Type_free_keyval(const dumpi_type_free_keyval * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2719,7 +2719,7 @@ on_MPI_Type_free_keyval(const dumpi_type_free_keyval *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_get_attr(const dumpi_type_get_attr *prm, uint16_t thread,
+on_MPI_Type_get_attr(const dumpi_type_get_attr * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2727,7 +2727,7 @@ on_MPI_Type_get_attr(const dumpi_type_get_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_get_contents(const dumpi_type_get_contents *prm, uint16_t thread,
+on_MPI_Type_get_contents(const dumpi_type_get_contents * /*prm*/, uint16_t  /*thread*/,
                          const dumpi_time *cpu, const dumpi_time *wall,
                          const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2735,7 +2735,7 @@ on_MPI_Type_get_contents(const dumpi_type_get_contents *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_get_envelope(const dumpi_type_get_envelope *prm, uint16_t thread,
+on_MPI_Type_get_envelope(const dumpi_type_get_envelope * /*prm*/, uint16_t  /*thread*/,
                          const dumpi_time *cpu, const dumpi_time *wall,
                          const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2743,7 +2743,7 @@ on_MPI_Type_get_envelope(const dumpi_type_get_envelope *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_get_name(const dumpi_type_get_name *prm, uint16_t thread,
+on_MPI_Type_get_name(const dumpi_type_get_name * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2751,7 +2751,7 @@ on_MPI_Type_get_name(const dumpi_type_get_name *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_set_attr(const dumpi_type_set_attr *prm, uint16_t thread,
+on_MPI_Type_set_attr(const dumpi_type_set_attr * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2759,7 +2759,7 @@ on_MPI_Type_set_attr(const dumpi_type_set_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_set_name(const dumpi_type_set_name *prm, uint16_t thread,
+on_MPI_Type_set_name(const dumpi_type_set_name * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2767,7 +2767,7 @@ on_MPI_Type_set_name(const dumpi_type_set_name *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_match_size(const dumpi_type_match_size *prm, uint16_t thread,
+on_MPI_Type_match_size(const dumpi_type_match_size * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2775,8 +2775,8 @@ on_MPI_Type_match_size(const dumpi_type_match_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_call_errhandler(const dumpi_win_call_errhandler *prm,
-                           uint16_t thread,
+on_MPI_Win_call_errhandler(const dumpi_win_call_errhandler * /*prm*/,
+                           uint16_t  /*thread*/,
                            const dumpi_time *cpu, const dumpi_time *wall,
                            const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2784,7 +2784,7 @@ on_MPI_Win_call_errhandler(const dumpi_win_call_errhandler *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_create_keyval(const dumpi_win_create_keyval *prm, uint16_t thread,
+on_MPI_Win_create_keyval(const dumpi_win_create_keyval * /*prm*/, uint16_t  /*thread*/,
                          const dumpi_time *cpu, const dumpi_time *wall,
                          const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2792,7 +2792,7 @@ on_MPI_Win_create_keyval(const dumpi_win_create_keyval *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_delete_attr(const dumpi_win_delete_attr *prm, uint16_t thread,
+on_MPI_Win_delete_attr(const dumpi_win_delete_attr * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2800,7 +2800,7 @@ on_MPI_Win_delete_attr(const dumpi_win_delete_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_free_keyval(const dumpi_win_free_keyval *prm, uint16_t thread,
+on_MPI_Win_free_keyval(const dumpi_win_free_keyval * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2808,7 +2808,7 @@ on_MPI_Win_free_keyval(const dumpi_win_free_keyval *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_get_attr(const dumpi_win_get_attr *prm, uint16_t thread,
+on_MPI_Win_get_attr(const dumpi_win_get_attr * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2816,7 +2816,7 @@ on_MPI_Win_get_attr(const dumpi_win_get_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_get_name(const dumpi_win_get_name *prm, uint16_t thread,
+on_MPI_Win_get_name(const dumpi_win_get_name * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2824,7 +2824,7 @@ on_MPI_Win_get_name(const dumpi_win_get_name *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_set_attr(const dumpi_win_set_attr *prm, uint16_t thread,
+on_MPI_Win_set_attr(const dumpi_win_set_attr * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2832,7 +2832,7 @@ on_MPI_Win_set_attr(const dumpi_win_set_attr *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_set_name(const dumpi_win_set_name *prm, uint16_t thread,
+on_MPI_Win_set_name(const dumpi_win_set_name * /*prm*/, uint16_t  /*thread*/,
                     const dumpi_time *cpu, const dumpi_time *wall,
                     const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2840,7 +2840,7 @@ on_MPI_Win_set_name(const dumpi_win_set_name *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Alloc_mem(const dumpi_alloc_mem *prm, uint16_t thread,
+on_MPI_Alloc_mem(const dumpi_alloc_mem * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2849,7 +2849,7 @@ on_MPI_Alloc_mem(const dumpi_alloc_mem *prm, uint16_t thread,
 
 int ParsedumpiCallbacks::
 on_MPI_Comm_create_errhandler
-(const dumpi_comm_create_errhandler *prm, uint16_t thread,
+(const dumpi_comm_create_errhandler * /*prm*/, uint16_t  /*thread*/,
  const dumpi_time *cpu, const dumpi_time *wall,
  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2857,8 +2857,8 @@ on_MPI_Comm_create_errhandler
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_get_errhandler(const dumpi_comm_get_errhandler *prm,
-                           uint16_t thread,
+on_MPI_Comm_get_errhandler(const dumpi_comm_get_errhandler * /*prm*/,
+                           uint16_t  /*thread*/,
                            const dumpi_time *cpu, const dumpi_time *wall,
                            const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2866,8 +2866,8 @@ on_MPI_Comm_get_errhandler(const dumpi_comm_get_errhandler *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Comm_set_errhandler(const dumpi_comm_set_errhandler *prm,
-                           uint16_t thread,
+on_MPI_Comm_set_errhandler(const dumpi_comm_set_errhandler * /*prm*/,
+                           uint16_t  /*thread*/,
                            const dumpi_time *cpu, const dumpi_time *wall,
                            const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2876,7 +2876,7 @@ on_MPI_Comm_set_errhandler(const dumpi_comm_set_errhandler *prm,
 
 int ParsedumpiCallbacks::
 on_MPI_File_create_errhandler
-(const dumpi_file_create_errhandler *prm, uint16_t thread,
+(const dumpi_file_create_errhandler * /*prm*/, uint16_t  /*thread*/,
  const dumpi_time *cpu, const dumpi_time *wall,
  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2884,8 +2884,8 @@ on_MPI_File_create_errhandler
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_errhandler(const dumpi_file_get_errhandler *prm,
-                           uint16_t thread,
+on_MPI_File_get_errhandler(const dumpi_file_get_errhandler * /*prm*/,
+                           uint16_t  /*thread*/,
                            const dumpi_time *cpu, const dumpi_time *wall,
                            const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2893,8 +2893,8 @@ on_MPI_File_get_errhandler(const dumpi_file_get_errhandler *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_set_errhandler(const dumpi_file_set_errhandler *prm,
-                           uint16_t thread,
+on_MPI_File_set_errhandler(const dumpi_file_set_errhandler * /*prm*/,
+                           uint16_t  /*thread*/,
                            const dumpi_time *cpu, const dumpi_time *wall,
                            const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2902,7 +2902,7 @@ on_MPI_File_set_errhandler(const dumpi_file_set_errhandler *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Finalized(const dumpi_finalized *prm, uint16_t thread,
+on_MPI_Finalized(const dumpi_finalized * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2910,7 +2910,7 @@ on_MPI_Finalized(const dumpi_finalized *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Free_mem(const dumpi_free_mem *prm, uint16_t thread,
+on_MPI_Free_mem(const dumpi_free_mem * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2918,7 +2918,7 @@ on_MPI_Free_mem(const dumpi_free_mem *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Get_address(const dumpi_get_address *prm, uint16_t thread,
+on_MPI_Get_address(const dumpi_get_address * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2926,7 +2926,7 @@ on_MPI_Get_address(const dumpi_get_address *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_create(const dumpi_info_create *prm, uint16_t thread,
+on_MPI_Info_create(const dumpi_info_create * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2934,7 +2934,7 @@ on_MPI_Info_create(const dumpi_info_create *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_delete(const dumpi_info_delete *prm, uint16_t thread,
+on_MPI_Info_delete(const dumpi_info_delete * /*prm*/, uint16_t  /*thread*/,
                    const dumpi_time *cpu, const dumpi_time *wall,
                    const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2942,7 +2942,7 @@ on_MPI_Info_delete(const dumpi_info_delete *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_dup(const dumpi_info_dup *prm, uint16_t thread,
+on_MPI_Info_dup(const dumpi_info_dup * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2950,7 +2950,7 @@ on_MPI_Info_dup(const dumpi_info_dup *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_free(const dumpi_info_free *prm, uint16_t thread,
+on_MPI_Info_free(const dumpi_info_free * /*prm*/, uint16_t  /*thread*/,
                  const dumpi_time *cpu, const dumpi_time *wall,
                  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2958,7 +2958,7 @@ on_MPI_Info_free(const dumpi_info_free *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_get(const dumpi_info_get *prm, uint16_t thread,
+on_MPI_Info_get(const dumpi_info_get * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2966,7 +2966,7 @@ on_MPI_Info_get(const dumpi_info_get *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_get_nkeys(const dumpi_info_get_nkeys *prm, uint16_t thread,
+on_MPI_Info_get_nkeys(const dumpi_info_get_nkeys * /*prm*/, uint16_t  /*thread*/,
                       const dumpi_time *cpu, const dumpi_time *wall,
                       const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2974,7 +2974,7 @@ on_MPI_Info_get_nkeys(const dumpi_info_get_nkeys *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_get_nthkey(const dumpi_info_get_nthkey *prm, uint16_t thread,
+on_MPI_Info_get_nthkey(const dumpi_info_get_nthkey * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2982,7 +2982,7 @@ on_MPI_Info_get_nthkey(const dumpi_info_get_nthkey *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_get_valuelen(const dumpi_info_get_valuelen *prm, uint16_t thread,
+on_MPI_Info_get_valuelen(const dumpi_info_get_valuelen * /*prm*/, uint16_t  /*thread*/,
                          const dumpi_time *cpu, const dumpi_time *wall,
                          const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2990,7 +2990,7 @@ on_MPI_Info_get_valuelen(const dumpi_info_get_valuelen *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Info_set(const dumpi_info_set *prm, uint16_t thread,
+on_MPI_Info_set(const dumpi_info_set * /*prm*/, uint16_t  /*thread*/,
                 const dumpi_time *cpu, const dumpi_time *wall,
                 const dumpi_perfinfo *perf, void *uarg)
 {
@@ -2998,7 +2998,7 @@ on_MPI_Info_set(const dumpi_info_set *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Pack_external(const dumpi_pack_external *prm, uint16_t thread,
+on_MPI_Pack_external(const dumpi_pack_external * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3006,7 +3006,7 @@ on_MPI_Pack_external(const dumpi_pack_external *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Pack_external_size(const dumpi_pack_external_size *prm, uint16_t thread,
+on_MPI_Pack_external_size(const dumpi_pack_external_size * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3014,7 +3014,7 @@ on_MPI_Pack_external_size(const dumpi_pack_external_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Request_get_status(const dumpi_request_get_status *prm, uint16_t thread,
+on_MPI_Request_get_status(const dumpi_request_get_status * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3022,68 +3022,68 @@ on_MPI_Request_get_status(const dumpi_request_get_status *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_create_darray(const dumpi_type_create_darray *prm, uint16_t thread,
-                          const dumpi_time *cpu, const dumpi_time *wall,
-                          const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Type_create_darray(const dumpi_type_create_darray * /*prm*/, uint16_t  /*thread*/,
+                          const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                          const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_create_darray");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_create_hindexed(const dumpi_type_create_hindexed *prm,
-                            uint16_t thread,
-                            const dumpi_time *cpu, const dumpi_time *wall,
-                            const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Type_create_hindexed(const dumpi_type_create_hindexed * /*prm*/,
+                            uint16_t  /*thread*/,
+                            const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                            const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_create_hindexed");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_create_hvector(const dumpi_type_create_hvector *prm,
-                           uint16_t thread,
-                           const dumpi_time *cpu, const dumpi_time *wall,
-                           const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Type_create_hvector(const dumpi_type_create_hvector * /*prm*/,
+                           uint16_t  /*thread*/,
+                           const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                           const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_create_hvector");
 }
 
 int ParsedumpiCallbacks::
 on_MPI_Type_create_indexed_block
-(const dumpi_type_create_indexed_block *prm, uint16_t thread,
- const dumpi_time *cpu, const dumpi_time *wall,
- const dumpi_perfinfo *perf, void *uarg)
+(const dumpi_type_create_indexed_block * /*prm*/, uint16_t  /*thread*/,
+ const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+ const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_create_indexed_block");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_create_resized(const dumpi_type_create_resized *prm,
-                           uint16_t thread,
-                           const dumpi_time *cpu, const dumpi_time *wall,
-                           const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Type_create_resized(const dumpi_type_create_resized * /*prm*/,
+                           uint16_t  /*thread*/,
+                           const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                           const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_create_resized");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_create_struct(const dumpi_type_create_struct *prm, uint16_t thread,
-                          const dumpi_time *cpu, const dumpi_time *wall,
-                          const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Type_create_struct(const dumpi_type_create_struct * /*prm*/, uint16_t  /*thread*/,
+                          const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                          const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_create_struct");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_create_subarray(const dumpi_type_create_subarray *prm,
-                            uint16_t thread,
-                            const dumpi_time *cpu, const dumpi_time *wall,
-                            const dumpi_perfinfo *perf, void *uarg)
+on_MPI_Type_create_subarray(const dumpi_type_create_subarray * /*prm*/,
+                            uint16_t  /*thread*/,
+                            const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                            const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_Type_create_subarray");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_get_extent(const dumpi_type_get_extent *prm, uint16_t thread,
+on_MPI_Type_get_extent(const dumpi_type_get_extent * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3091,8 +3091,8 @@ on_MPI_Type_get_extent(const dumpi_type_get_extent *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Type_get_true_extent(const dumpi_type_get_true_extent *prm,
-                            uint16_t thread,
+on_MPI_Type_get_true_extent(const dumpi_type_get_true_extent * /*prm*/,
+                            uint16_t  /*thread*/,
                             const dumpi_time *cpu, const dumpi_time *wall,
                             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3100,7 +3100,7 @@ on_MPI_Type_get_true_extent(const dumpi_type_get_true_extent *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Unpack_external(const dumpi_unpack_external *prm, uint16_t thread,
+on_MPI_Unpack_external(const dumpi_unpack_external * /*prm*/, uint16_t  /*thread*/,
                        const dumpi_time *cpu, const dumpi_time *wall,
                        const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3108,8 +3108,8 @@ on_MPI_Unpack_external(const dumpi_unpack_external *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_create_errhandler(const dumpi_win_create_errhandler *prm,
-                             uint16_t thread,
+on_MPI_Win_create_errhandler(const dumpi_win_create_errhandler * /*prm*/,
+                             uint16_t  /*thread*/,
                              const dumpi_time *cpu, const dumpi_time *wall,
                              const dumpi_perfinfo *perf, void*uarg)
 {
@@ -3117,7 +3117,7 @@ on_MPI_Win_create_errhandler(const dumpi_win_create_errhandler *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_get_errhandler(const dumpi_win_get_errhandler *prm, uint16_t thread,
+on_MPI_Win_get_errhandler(const dumpi_win_get_errhandler * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3125,7 +3125,7 @@ on_MPI_Win_get_errhandler(const dumpi_win_get_errhandler *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Win_set_errhandler(const dumpi_win_set_errhandler *prm, uint16_t thread,
+on_MPI_Win_set_errhandler(const dumpi_win_set_errhandler * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3133,31 +3133,31 @@ on_MPI_Win_set_errhandler(const dumpi_win_set_errhandler *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_open(const dumpi_file_open *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_open(const dumpi_file_open * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_open");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_close(const dumpi_file_close *prm, uint16_t thread,
-                  const dumpi_time *cpu, const dumpi_time *wall,
-                  const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_close(const dumpi_file_close * /*prm*/, uint16_t  /*thread*/,
+                  const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                  const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_close");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_delete(const dumpi_file_delete *prm, uint16_t thread,
-                   const dumpi_time *cpu, const dumpi_time *wall,
-                   const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_delete(const dumpi_file_delete * /*prm*/, uint16_t  /*thread*/,
+                   const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                   const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_delete");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_set_size(const dumpi_file_set_size *prm, uint16_t thread,
+on_MPI_File_set_size(const dumpi_file_set_size * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3165,15 +3165,15 @@ on_MPI_File_set_size(const dumpi_file_set_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_preallocate(const dumpi_file_preallocate *prm, uint16_t thread,
-                        const dumpi_time *cpu, const dumpi_time *wall,
-                        const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_preallocate(const dumpi_file_preallocate * /*prm*/, uint16_t  /*thread*/,
+                        const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                        const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_preallocate");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_size(const dumpi_file_get_size *prm, uint16_t thread,
+on_MPI_File_get_size(const dumpi_file_get_size * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3181,7 +3181,7 @@ on_MPI_File_get_size(const dumpi_file_get_size *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_group(const dumpi_file_get_group *prm, uint16_t thread,
+on_MPI_File_get_group(const dumpi_file_get_group * /*prm*/, uint16_t  /*thread*/,
                       const dumpi_time *cpu, const dumpi_time *wall,
                       const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3189,7 +3189,7 @@ on_MPI_File_get_group(const dumpi_file_get_group *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_amode(const dumpi_file_get_amode *prm, uint16_t thread,
+on_MPI_File_get_amode(const dumpi_file_get_amode * /*prm*/, uint16_t  /*thread*/,
                       const dumpi_time *cpu, const dumpi_time *wall,
                       const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3197,7 +3197,7 @@ on_MPI_File_get_amode(const dumpi_file_get_amode *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_set_info(const dumpi_file_set_info *prm, uint16_t thread,
+on_MPI_File_set_info(const dumpi_file_set_info * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3205,7 +3205,7 @@ on_MPI_File_set_info(const dumpi_file_set_info *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_info(const dumpi_file_get_info *prm, uint16_t thread,
+on_MPI_File_get_info(const dumpi_file_get_info * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3213,7 +3213,7 @@ on_MPI_File_get_info(const dumpi_file_get_info *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_set_view(const dumpi_file_set_view *prm, uint16_t thread,
+on_MPI_File_set_view(const dumpi_file_set_view * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3221,7 +3221,7 @@ on_MPI_File_set_view(const dumpi_file_set_view *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_view(const dumpi_file_get_view *prm, uint16_t thread,
+on_MPI_File_get_view(const dumpi_file_get_view * /*prm*/, uint16_t  /*thread*/,
                      const dumpi_time *cpu, const dumpi_time *wall,
                      const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3229,111 +3229,111 @@ on_MPI_File_get_view(const dumpi_file_get_view *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_at(const dumpi_file_read_at *prm, uint16_t thread,
-                    const dumpi_time *cpu, const dumpi_time *wall,
-                    const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read_at(const dumpi_file_read_at * /*prm*/, uint16_t  /*thread*/,
+                    const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                    const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_at");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_at_all(const dumpi_file_read_at_all *prm, uint16_t thread,
-                        const dumpi_time *cpu, const dumpi_time *wall,
-                        const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read_at_all(const dumpi_file_read_at_all * /*prm*/, uint16_t  /*thread*/,
+                        const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                        const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_at_all");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write_at(const dumpi_file_write_at *prm, uint16_t thread,
-                     const dumpi_time *cpu, const dumpi_time *wall,
-                     const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_write_at(const dumpi_file_write_at * /*prm*/, uint16_t  /*thread*/,
+                     const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                     const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_at");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write_at_all(const dumpi_file_write_at_all *prm, uint16_t thread,
-                         const dumpi_time *cpu, const dumpi_time *wall,
-                         const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_write_at_all(const dumpi_file_write_at_all * /*prm*/, uint16_t  /*thread*/,
+                         const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                         const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_at_all");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_iread_at(const dumpi_file_iread_at *prm, uint16_t thread,
-                     const dumpi_time *cpu, const dumpi_time *wall,
-                     const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_iread_at(const dumpi_file_iread_at * /*prm*/, uint16_t  /*thread*/,
+                     const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                     const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_iread_at");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_iwrite_at(const dumpi_file_iwrite_at *prm, uint16_t thread,
-                      const dumpi_time *cpu, const dumpi_time *wall,
-                      const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_iwrite_at(const dumpi_file_iwrite_at * /*prm*/, uint16_t  /*thread*/,
+                      const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                      const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_iwrite_at");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read(const dumpi_file_read *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read(const dumpi_file_read * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_all(const dumpi_file_read_all *prm, uint16_t thread,
-                     const dumpi_time *cpu, const dumpi_time *wall,
-                     const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read_all(const dumpi_file_read_all * /*prm*/, uint16_t  /*thread*/,
+                     const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                     const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_all");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write(const dumpi_file_write *prm, uint16_t thread,
-                  const dumpi_time *cpu, const dumpi_time *wall,
-                  const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_write(const dumpi_file_write * /*prm*/, uint16_t  /*thread*/,
+                  const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                  const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write_all(const dumpi_file_write_all *prm, uint16_t thread,
-                      const dumpi_time *cpu, const dumpi_time *wall,
-                      const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_write_all(const dumpi_file_write_all * /*prm*/, uint16_t  /*thread*/,
+                      const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                      const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_all");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_iread(const dumpi_file_iread *prm, uint16_t thread,
-                  const dumpi_time *cpu, const dumpi_time *wall,
-                  const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_iread(const dumpi_file_iread * /*prm*/, uint16_t  /*thread*/,
+                  const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                  const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_iread");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_iwrite(const dumpi_file_iwrite *prm, uint16_t thread,
-                   const dumpi_time *cpu, const dumpi_time *wall,
-                   const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_iwrite(const dumpi_file_iwrite * /*prm*/, uint16_t  /*thread*/,
+                   const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                   const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_iwrite");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_seek(const dumpi_file_seek *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_seek(const dumpi_file_seek * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_seek");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_position(const dumpi_file_get_position *prm, uint16_t thread,
+on_MPI_File_get_position(const dumpi_file_get_position * /*prm*/, uint16_t  /*thread*/,
                          const dumpi_time *cpu, const dumpi_time *wall,
                          const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3341,8 +3341,8 @@ on_MPI_File_get_position(const dumpi_file_get_position *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_byte_offset(const dumpi_file_get_byte_offset *prm,
-                            uint16_t thread,
+on_MPI_File_get_byte_offset(const dumpi_file_get_byte_offset * /*prm*/,
+                            uint16_t  /*thread*/,
                             const dumpi_time *cpu, const dumpi_time *wall,
                             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3350,64 +3350,64 @@ on_MPI_File_get_byte_offset(const dumpi_file_get_byte_offset *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_shared(const dumpi_file_read_shared *prm, uint16_t thread,
-                        const dumpi_time *cpu, const dumpi_time *wall,
-                        const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read_shared(const dumpi_file_read_shared * /*prm*/, uint16_t  /*thread*/,
+                        const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                        const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_shared");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write_shared(const dumpi_file_write_shared *prm, uint16_t thread,
-                         const dumpi_time *cpu, const dumpi_time *wall,
-                         const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_write_shared(const dumpi_file_write_shared * /*prm*/, uint16_t  /*thread*/,
+                         const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                         const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_shared");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_iread_shared(const dumpi_file_iread_shared *prm, uint16_t thread,
-                         const dumpi_time *cpu, const dumpi_time *wall,
-                         const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_iread_shared(const dumpi_file_iread_shared * /*prm*/, uint16_t  /*thread*/,
+                         const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                         const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_iread_shared");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_iwrite_shared(const dumpi_file_iwrite_shared *prm, uint16_t thread,
-                          const dumpi_time *cpu, const dumpi_time *wall,
-                          const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_iwrite_shared(const dumpi_file_iwrite_shared * /*prm*/, uint16_t  /*thread*/,
+                          const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                          const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_iwrite_shared");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_ordered(const dumpi_file_read_ordered *prm, uint16_t thread,
-                         const dumpi_time *cpu, const dumpi_time *wall,
-                         const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read_ordered(const dumpi_file_read_ordered * /*prm*/, uint16_t  /*thread*/,
+                         const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                         const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_ordered");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write_ordered(const dumpi_file_write_ordered *prm, uint16_t thread,
-                          const dumpi_time *cpu, const dumpi_time *wall,
-                          const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_write_ordered(const dumpi_file_write_ordered * /*prm*/, uint16_t  /*thread*/,
+                          const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                          const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_ordered");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_seek_shared(const dumpi_file_seek_shared *prm, uint16_t thread,
-                        const dumpi_time *cpu, const dumpi_time *wall,
-                        const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_seek_shared(const dumpi_file_seek_shared * /*prm*/, uint16_t  /*thread*/,
+                        const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                        const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_seek_shared");
 }
 
 int ParsedumpiCallbacks::
 on_MPI_File_get_position_shared
-(const dumpi_file_get_position_shared *prm, uint16_t thread,
+(const dumpi_file_get_position_shared * /*prm*/, uint16_t  /*thread*/,
  const dumpi_time *cpu, const dumpi_time *wall,
  const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3416,113 +3416,113 @@ on_MPI_File_get_position_shared
 
 int ParsedumpiCallbacks::
 on_MPI_File_read_at_all_begin
-(const dumpi_file_read_at_all_begin *prm, uint16_t thread,
- const dumpi_time *cpu, const dumpi_time *wall,
- const dumpi_perfinfo *perf, void *uarg)
+(const dumpi_file_read_at_all_begin * /*prm*/, uint16_t  /*thread*/,
+ const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+ const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_at_all_begin");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_at_all_end(const dumpi_file_read_at_all_end *prm,
-                            uint16_t thread,
-                            const dumpi_time *cpu, const dumpi_time *wall,
-                            const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read_at_all_end(const dumpi_file_read_at_all_end * /*prm*/,
+                            uint16_t  /*thread*/,
+                            const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                            const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_at_all_end");
 }
 
 int ParsedumpiCallbacks::
 on_MPI_File_write_at_all_begin
-(const dumpi_file_write_at_all_begin *prm, uint16_t thread,
- const dumpi_time *cpu, const dumpi_time *wall,
- const dumpi_perfinfo *perf, void *uarg)
+(const dumpi_file_write_at_all_begin * /*prm*/, uint16_t  /*thread*/,
+ const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+ const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_at_all_begin");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write_at_all_end(const dumpi_file_write_at_all_end *prm,
-                             uint16_t thread,
-                             const dumpi_time *cpu, const dumpi_time *wall,
-                             const dumpi_perfinfo *perf,void *uarg)
+on_MPI_File_write_at_all_end(const dumpi_file_write_at_all_end * /*prm*/,
+                             uint16_t  /*thread*/,
+                             const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                             const dumpi_perfinfo * /*perf*/,void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_at_all_end");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_all_begin(const dumpi_file_read_all_begin *prm,
-                           uint16_t thread,
-                           const dumpi_time *cpu, const dumpi_time *wall,
-                           const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read_all_begin(const dumpi_file_read_all_begin * /*prm*/,
+                           uint16_t  /*thread*/,
+                           const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                           const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_all_begin");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_all_end(const dumpi_file_read_all_end *prm, uint16_t thread,
-                         const dumpi_time *cpu, const dumpi_time *wall,
-                         const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_read_all_end(const dumpi_file_read_all_end * /*prm*/, uint16_t  /*thread*/,
+                         const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                         const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_all_end");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write_all_begin(const dumpi_file_write_all_begin *prm,
-                            uint16_t thread,
-                            const dumpi_time *cpu, const dumpi_time *wall,
-                            const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_write_all_begin(const dumpi_file_write_all_begin * /*prm*/,
+                            uint16_t  /*thread*/,
+                            const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                            const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_all_begin");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_write_all_end(const dumpi_file_write_all_end *prm, uint16_t thread,
-                          const dumpi_time *cpu, const dumpi_time *wall,
-                          const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_write_all_end(const dumpi_file_write_all_end * /*prm*/, uint16_t  /*thread*/,
+                          const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                          const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_all_end");
 }
 
 int ParsedumpiCallbacks::
 on_MPI_File_read_ordered_begin
-(const dumpi_file_read_ordered_begin *prm, uint16_t thread,
- const dumpi_time *cpu, const dumpi_time *wall,
- const dumpi_perfinfo *perf, void *uarg)
+(const dumpi_file_read_ordered_begin * /*prm*/, uint16_t  /*thread*/,
+ const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+ const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_ordered_begin");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_read_ordered_end(const dumpi_file_read_ordered_end *prm,
-                             uint16_t thread,
-                             const dumpi_time *cpu, const dumpi_time *wall,
-                             const dumpi_perfinfo *perf, void*uarg)
+on_MPI_File_read_ordered_end(const dumpi_file_read_ordered_end * /*prm*/,
+                             uint16_t  /*thread*/,
+                             const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                             const dumpi_perfinfo * /*perf*/, void* /*uarg*/)
 {
   return not_implemented("on_MPI_File_read_ordered_end");
 }
 
 int ParsedumpiCallbacks::
 on_MPI_File_write_ordered_begin
-(const dumpi_file_write_ordered_begin *prm, uint16_t thread,
- const dumpi_time *cpu, const dumpi_time *wall,
- const dumpi_perfinfo *perf, void *uarg)
+(const dumpi_file_write_ordered_begin * /*prm*/, uint16_t  /*thread*/,
+ const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+ const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_ordered_begin");
 }
 
 int ParsedumpiCallbacks::
 on_MPI_File_write_ordered_end
-(const dumpi_file_write_ordered_end *prm, uint16_t thread,
- const dumpi_time *cpu, const dumpi_time *wall,
- const dumpi_perfinfo *perf, void *uarg)
+(const dumpi_file_write_ordered_end * /*prm*/, uint16_t  /*thread*/,
+ const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+ const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_write_ordered_end");
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_type_extent(const dumpi_file_get_type_extent *prm,
-                            uint16_t thread,
+on_MPI_File_get_type_extent(const dumpi_file_get_type_extent * /*prm*/,
+                            uint16_t  /*thread*/,
                             const dumpi_time *cpu, const dumpi_time *wall,
                             const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3530,7 +3530,7 @@ on_MPI_File_get_type_extent(const dumpi_file_get_type_extent *prm,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_Register_datarep(const dumpi_register_datarep *prm, uint16_t thread,
+on_MPI_Register_datarep(const dumpi_register_datarep * /*prm*/, uint16_t  /*thread*/,
                         const dumpi_time *cpu, const dumpi_time *wall,
                         const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3538,7 +3538,7 @@ on_MPI_Register_datarep(const dumpi_register_datarep *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_set_atomicity(const dumpi_file_set_atomicity *prm, uint16_t thread,
+on_MPI_File_set_atomicity(const dumpi_file_set_atomicity * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3546,7 +3546,7 @@ on_MPI_File_set_atomicity(const dumpi_file_set_atomicity *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_get_atomicity(const dumpi_file_get_atomicity *prm, uint16_t thread,
+on_MPI_File_get_atomicity(const dumpi_file_get_atomicity * /*prm*/, uint16_t  /*thread*/,
                           const dumpi_time *cpu, const dumpi_time *wall,
                           const dumpi_perfinfo *perf, void *uarg)
 {
@@ -3554,73 +3554,73 @@ on_MPI_File_get_atomicity(const dumpi_file_get_atomicity *prm, uint16_t thread,
 }
 
 int ParsedumpiCallbacks::
-on_MPI_File_sync(const dumpi_file_sync *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPI_File_sync(const dumpi_file_sync * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPI_File_sync");
 }
 
 int ParsedumpiCallbacks::
-on_MPIO_Test(const dumpio_test *prm, uint16_t thread,
-             const dumpi_time *cpu, const dumpi_time *wall,
-             const dumpi_perfinfo *perf, void *uarg)
+on_MPIO_Test(const dumpio_test * /*prm*/, uint16_t  /*thread*/,
+             const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+             const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPIO_Test");
 }
 
 int ParsedumpiCallbacks::
-on_MPIO_Wait(const dumpio_wait *prm, uint16_t thread,
-             const dumpi_time *cpu, const dumpi_time *wall,
-             const dumpi_perfinfo *perf, void *uarg)
+on_MPIO_Wait(const dumpio_wait * /*prm*/, uint16_t  /*thread*/,
+             const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+             const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPIO_Wait");
 }
 
 int ParsedumpiCallbacks::
-on_MPIO_Testall(const dumpio_testall *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPIO_Testall(const dumpio_testall * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPIO_Testall");
 }
 
 int ParsedumpiCallbacks::
-on_MPIO_Waitall(const dumpio_waitall *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPIO_Waitall(const dumpio_waitall * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPIO_Waitall");
 }
 
 int ParsedumpiCallbacks::
-on_MPIO_Testany(const dumpio_testany *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPIO_Testany(const dumpio_testany * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPIO_Testany");
 }
 
 int ParsedumpiCallbacks::
-on_MPIO_Waitany(const dumpio_waitany *prm, uint16_t thread,
-                const dumpi_time *cpu, const dumpi_time *wall,
-                const dumpi_perfinfo *perf, void *uarg)
+on_MPIO_Waitany(const dumpio_waitany * /*prm*/, uint16_t  /*thread*/,
+                const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPIO_Waitany");
 }
 
 int ParsedumpiCallbacks::
-on_MPIO_Waitsome(const dumpio_waitsome *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPIO_Waitsome(const dumpio_waitsome * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPIO_Waitsome");
 }
 
 int ParsedumpiCallbacks::
-on_MPIO_Testsome(const dumpio_testsome *prm, uint16_t thread,
-                 const dumpi_time *cpu, const dumpi_time *wall,
-                 const dumpi_perfinfo *perf, void *uarg)
+on_MPIO_Testsome(const dumpio_testsome * /*prm*/, uint16_t  /*thread*/,
+                 const dumpi_time * /*cpu*/, const dumpi_time * /*wall*/,
+                 const dumpi_perfinfo * /*perf*/, void * /*uarg*/)
 {
   return not_implemented("on_MPIO_Testsome");
 }

--- a/sstmac/skeletons/undumpi/parsedumpi_callbacks.cc
+++ b/sstmac/skeletons/undumpi/parsedumpi_callbacks.cc
@@ -858,7 +858,7 @@ on_MPI_Waitany(const dumpi_waitany *prm, uint16_t thread,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
-  ParsedumpiCallbacks *cb = reinterpret_cast<ParsedumpiCallbacks*>(uarg);
+  // TODOWARNING ParsedumpiCallbacks *cb = reinterpret_cast<ParsedumpiCallbacks*>(uarg);
   return waitany_pessimistic(prm, thread, cpu, wall, perf, uarg);
 }
 
@@ -891,7 +891,7 @@ on_MPI_Testany(const dumpi_testany *prm, uint16_t thread,
                const dumpi_time *cpu, const dumpi_time *wall,
                const dumpi_perfinfo *perf, void *uarg)
 {
-  ParsedumpiCallbacks *cb = reinterpret_cast<ParsedumpiCallbacks*>(uarg);
+  // TODOWARNING ParsedumpiCallbacks *cb = reinterpret_cast<ParsedumpiCallbacks*>(uarg);
   return testany_pessimistic(prm, thread, cpu, wall, perf, uarg);
 }
 
@@ -1228,7 +1228,7 @@ on_MPI_Type_vector(const dumpi_type_vector *prm, uint16_t thread,
   }
   cb->start_mpi(cpu, wall, perf);
   MPI_Datatype oldtype = cb->getMpitype(prm->oldtype);
-  MpiType* old_type_obj = cb->getmpi()->typeFromId(oldtype);
+  // TODOWARNING MpiType* old_type_obj = cb->getmpi()->typeFromId(oldtype);
 
   MPI_Datatype newtype;
   cb->getmpi()->typeVector(prm->count, prm->blocklength, 0, oldtype, &newtype);

--- a/sstmac/software/api/api.cc
+++ b/sstmac/software/api/api.cc
@@ -124,7 +124,7 @@ API::scheduleDelay(TimeDelta t, ExecutionEvent* ev)
   parent_->os()->sendDelayedExecutionEvent(t, ev);
 }
 
-API::API(SST::Params &params, App *parent, SST::Component* comp) :
+API::API(SST::Params & /*params*/, App *parent, SST::Component*  /*comp*/) :
   host_timer_(nullptr),
   parent_(parent)
 {

--- a/sstmac/software/api/api.cc
+++ b/sstmac/software/api/api.cc
@@ -125,8 +125,8 @@ API::scheduleDelay(TimeDelta t, ExecutionEvent* ev)
 }
 
 API::API(SST::Params &params, App *parent, SST::Component* comp) :
-  parent_(parent),
-  host_timer_(nullptr)
+  host_timer_(nullptr),
+  parent_(parent)
 {
   //host_timer_(new HostTimer)
 }

--- a/sstmac/software/launch/app_launcher.cc
+++ b/sstmac/software/launch/app_launcher.cc
@@ -112,7 +112,7 @@ LaunchRequest::cloneInjectionAck() const
 }
 
 int
-StartAppRequest::coreAffinity(int intranode_rank) const
+StartAppRequest::coreAffinity(int  /*intranode_rank*/) const
 {
   return Thread::no_core_affinity;
 }

--- a/sstmac/software/launch/app_launcher.cc
+++ b/sstmac/software/launch/app_launcher.cc
@@ -57,8 +57,8 @@ namespace sstmac {
 namespace sw {
 
 AppLauncher::AppLauncher(OperatingSystem* os) :
-  is_completed_(false),
-  Service(std::string("launcher"), SoftwareId(0,0), os)
+  Service(std::string("launcher"), SoftwareId(0,0), os),
+  is_completed_(false)
 {
 }
 

--- a/sstmac/software/launch/cart_allocation.cc
+++ b/sstmac/software/launch/cart_allocation.cc
@@ -91,7 +91,7 @@ void
 CartAllocation::insert(
   hw::CartesianTopology* regtop,
   const std::vector<int>& coords,
-  const ordered_node_set& available,
+  const ordered_node_set&  /*available*/,
   ordered_node_set& allocation) const
 {
   NodeId nid = regtop->node_addr(coords);

--- a/sstmac/software/launch/coordinate_allocation.cc
+++ b/sstmac/software/launch/coordinate_allocation.cc
@@ -99,7 +99,7 @@ CoordinateAllocation::readCoordinateFile(
 bool
 CoordinateAllocation::allocate(
   int nnode_requested,
-  const ordered_node_set& available,
+  const ordered_node_set&  /*available*/,
   ordered_node_set& allocation) const
 {
   std::vector<hw::coordinates> node_list;

--- a/sstmac/software/launch/coordinate_task_mapper.cc
+++ b/sstmac/software/launch/coordinate_task_mapper.cc
@@ -66,10 +66,10 @@ CoordinateTaskMapper::CoordinateTaskMapper(SST::Params& params) :
 
 void
 CoordinateTaskMapper::mapRanks(
-  const ordered_node_set& nodes,
-  int ppn,
+  const ordered_node_set&  /*nodes*/,
+  int  /*ppn*/,
   std::vector<NodeId> &result,
-  int nproc)
+  int  /*nproc*/)
 {
   hw::CartesianTopology* regtop = safe_cast(hw::CartesianTopology, topology_);
 

--- a/sstmac/software/launch/dumpi_allocation.cc
+++ b/sstmac/software/launch/dumpi_allocation.cc
@@ -69,8 +69,8 @@ DumpiAllocation::DumpiAllocation(SST::Params& params)
 
 bool
 DumpiAllocation::allocate(
-  int nnode_requested,
-   const ordered_node_set& available,
+  int  /*nnode_requested*/,
+   const ordered_node_set&  /*available*/,
    ordered_node_set& allocation) const
 {
   DumpiMeta* meta = new DumpiMeta(metafile_);

--- a/sstmac/software/launch/dumpi_task_mapper.cc
+++ b/sstmac/software/launch/dumpi_task_mapper.cc
@@ -87,10 +87,10 @@ DumpiTaskMapper::DumpiTaskMapper(SST::Params& params) :
 
 void
 DumpiTaskMapper::mapRanks(
-  const ordered_node_set& nodes,
-  int ppn,
+  const ordered_node_set&  /*nodes*/,
+  int  /*ppn*/,
   std::vector<NodeId> &result,
-  int nproc)
+  int  /*nproc*/)
 {
   DumpiMeta* meta = new DumpiMeta(metaname_);
 

--- a/sstmac/software/launch/hostname_allocation.cc
+++ b/sstmac/software/launch/hostname_allocation.cc
@@ -69,8 +69,8 @@ HostnameAllocation::HostnameAllocation(SST::Params& params) :
 
 void
 HostnameAllocation::readHostFile(
-  ParallelRuntime* rt,
-  const char* here,
+  ParallelRuntime*  /*rt*/,
+  const char*  /*here*/,
   const std::string &hostfile,
   std::vector<std::string>& hosts)
 {
@@ -86,8 +86,8 @@ HostnameAllocation::readHostFile(
 }
 
 bool
-HostnameAllocation::allocate(int nnode_requested,
- const ordered_node_set& available,
+HostnameAllocation::allocate(int  /*nnode_requested*/,
+ const ordered_node_set&  /*available*/,
  ordered_node_set &allocation) const
 {
   std::vector< std::string > hosts;

--- a/sstmac/software/launch/hostname_task_mapper.cc
+++ b/sstmac/software/launch/hostname_task_mapper.cc
@@ -69,8 +69,8 @@ HostnameTaskMapper::HostnameTaskMapper(SST::Params& params) :
 
 void
 HostnameTaskMapper::mapRanks(
-  const ordered_node_set& nodes,
-  int ppn,
+  const ordered_node_set&  /*nodes*/,
+  int  /*ppn*/,
   std::vector<NodeId> &result,
   int nproc)
 {

--- a/sstmac/software/launch/job_launch_event.h
+++ b/sstmac/software/launch/job_launch_event.h
@@ -67,7 +67,7 @@ class job_launch_event :
   }
 
  private:
-  int appnum_;
+  // TODOWARNING int appnum_;
   AppLaunchRequest* appman_;
 };
 

--- a/sstmac/software/launch/job_launcher.cc
+++ b/sstmac/software/launch/job_launcher.cc
@@ -222,7 +222,7 @@ DefaultJoblauncher::handleLaunchRequest(AppLaunchRequest* request,
 }
 
 void
-DefaultJoblauncher::stopEventReceived(JobStopRequest *ev)
+DefaultJoblauncher::stopEventReceived(JobStopRequest * /*ev*/)
 {
   os_->decrementAppRefcount();
 }
@@ -240,7 +240,7 @@ ExclusiveJoblauncher::handleLaunchRequest(AppLaunchRequest *request, ordered_nod
 }
 
 void
-ExclusiveJoblauncher::stopEventReceived(JobStopRequest *ev)
+ExclusiveJoblauncher::stopEventReceived(JobStopRequest * /*ev*/)
 {
   active_job_ = nullptr;
   if (!pending_requests_.empty()){

--- a/sstmac/software/launch/job_launcher.h
+++ b/sstmac/software/launch/job_launcher.h
@@ -277,7 +277,6 @@ struct IncastIterator {
     while (power2_size < nranks_){
       power2_size *= 2;
     }
-    int ret = 0;
     num_to_send = 0;
     num_to_recv = 0;
     pvt_config(num_to_send, num_to_recv, to_send, to_recv, 0, power2_size);

--- a/sstmac/software/launch/launch_event.h
+++ b/sstmac/software/launch/launch_event.h
@@ -95,11 +95,12 @@ class LaunchRequest : public hw::NetworkMessage
                const std::string& unique_name,
                NodeId to, NodeId from,
                const std::string& libname) :
-    ty_(ty), tid_(tid),
-    unique_name_(unique_name),
     NetworkMessage(0/**qos**/, flow_id, libname, aid, to, from,
                    256, //use rough fixed size to avoid platform-dependent sizeof(...)
-                   false, nullptr, header{})
+                   false, nullptr, header{}),
+    tid_(tid),
+    unique_name_(unique_name),
+    ty_(ty)
   {
   }
 

--- a/sstmac/software/launch/node_id_allocation.cc
+++ b/sstmac/software/launch/node_id_allocation.cc
@@ -104,7 +104,7 @@ NodeIdAllocation::readCoordinateFile(
 
 bool
 NodeIdAllocation::allocate(int nnode_requested,
-  const ordered_node_set& available,
+  const ordered_node_set&  /*available*/,
   ordered_node_set &allocation) const
 {
   std::vector<NodeId> node_list;

--- a/sstmac/software/launch/node_id_task_mapper.cc
+++ b/sstmac/software/launch/node_id_task_mapper.cc
@@ -78,7 +78,7 @@ NodeIdTaskMapper::NodeIdTaskMapper(SST::Params& params) :
 void
 NodeIdTaskMapper::mapRanks(
   const ordered_node_set& nodes,
-  int ppn,
+  int  /*ppn*/,
   std::vector<NodeId> &result,
   int nproc)
 {

--- a/sstmac/software/launch/task_mapper.cc
+++ b/sstmac/software/launch/task_mapper.cc
@@ -57,10 +57,11 @@ TaskMapper::~TaskMapper() throw()
 }
 
 TaskMapper::TaskMapper(SST::Params& params) :
-  rt_(nullptr), topology_(nullptr)
+  topology_(sstmac::hw::Topology::staticTopology(params)),
+  rt_(ParallelRuntime::staticRuntime(params))
 {
-  rt_ = ParallelRuntime::staticRuntime(params);
-  topology_ = sstmac::hw::Topology::staticTopology(params);
+  // TODOWARNING rt_ = ParallelRuntime::staticRuntime(params);
+  // TODOWARNING topology_ = sstmac::hw::Topology::staticTopology(params);
 }
 
 int

--- a/sstmac/software/libraries/compute/lib_compute.h
+++ b/sstmac/software/libraries/compute/lib_compute.h
@@ -60,13 +60,13 @@ class LibCompute :
   virtual ~LibCompute(){}
 
  protected:
-  LibCompute(SST::Params& params,
+  LibCompute(SST::Params&  /*params*/,
               const std::string& libname, SoftwareId sid,
               OperatingSystem* os)
     : Library(libname, sid, os) {
   }
 
-  LibCompute(SST::Params& params,
+  LibCompute(SST::Params&  /*params*/,
               const char* name, SoftwareId sid,
               OperatingSystem* os)
     : Library(name, sid, os)

--- a/sstmac/software/libraries/compute/lib_compute_inst.cc
+++ b/sstmac/software/libraries/compute/lib_compute_inst.cc
@@ -96,7 +96,7 @@ LibComputeInst::computeDetailed(
   st.nthread = nthread;
 
   // Do not overwrite an existing tag
-  const auto& cur_tag = os_->activeThread()->tag();
+  // TODOWARNING const auto& cur_tag = os_->activeThread()->tag();
   FTQScope scope(os_->activeThread(), FTQTag::compute);
 
   computeInst(cmsg, nthread);

--- a/sstmac/software/libraries/library.cc
+++ b/sstmac/software/libraries/library.cc
@@ -64,7 +64,7 @@ Library::~Library()
 }
 
 void
-Library::incomingEvent(Event* ev)
+Library::incomingEvent(Event*  /*ev*/)
 {
   spkt_throw_printf(sprockit::UnimplementedError,
     "%s::incomingEvent: this library should only block, never receive incoming",
@@ -72,7 +72,7 @@ Library::incomingEvent(Event* ev)
 }
 
 void
-Library::incomingRequest(Request* ev)
+Library::incomingRequest(Request*  /*ev*/)
 {
   spkt_throw_printf(sprockit::UnimplementedError,
     "%s::incomingRequest: this library should only block, never receive incoming",

--- a/sstmac/software/libraries/library.cc
+++ b/sstmac/software/libraries/library.cc
@@ -50,8 +50,10 @@ namespace sstmac {
 namespace sw {
 
 Library::Library(const std::string& libname, SoftwareId sid, OperatingSystem* os) :
-  sid_(sid), libname_(libname), os_(os),
-  addr_(os->addr())
+  os_(os),
+  sid_(sid), 
+  addr_(os->addr()),
+  libname_(libname) 
 {
   os_->registerLib(this);
 }

--- a/sstmac/software/process/app.cc
+++ b/sstmac/software/process/app.cc
@@ -210,14 +210,14 @@ App::allocateDataSegment(bool tls)
 App::App(SST::Params& params, SoftwareId sid,
          OperatingSystem* os) :
   Thread(params, sid, os),
-  compute_lib_(nullptr),
   params_(params),
+  compute_lib_(nullptr),
   next_tls_key_(0),
   next_condition_(0),
-  notify_(true),
   next_mutex_(0),
   min_op_cutoff_(0),
   globals_storage_(nullptr),
+  notify_(true),
   rc_(0)
 {
   globals_storage_ = allocateDataSegment(false); //not tls

--- a/sstmac/software/process/backtrace.h
+++ b/sstmac/software/process/backtrace.h
@@ -104,13 +104,14 @@ class CallGraphIncrementStack
 }
 }
 
+#include <unusedvariablemacro.h>
 #if SSTMAC_HAVE_CALL_GRAPH
 #define CallGraphAppend(name) \
   struct graph_viz_##name : public sstmac::sw::CallGraphID<graph_viz_##name> {}; \
   static sstmac::sw::CallGraphRegistration __call_graph_register_variable__(#name, graph_viz_##name::id); \
   ::sstmac::sw::CallGraphIncrementStack __call_graph_append_variable__(graph_viz_##name::id)
 #else
-#define CallGraphAppend(...) int __call_graph_append_variable__
+#define CallGraphAppend(...) SSTMAC_MAYBE_UNUSED int __call_graph_append_variable__
 #endif
 
 #endif

--- a/sstmac/software/process/compute_scheduler.h
+++ b/sstmac/software/process/compute_scheduler.h
@@ -67,7 +67,9 @@ class ComputeScheduler
 
   ComputeScheduler(SST::Params& params, sw::OperatingSystem* os,
                     int ncores, int nsockets) :
-    os_(os), ncores_(ncores), nsocket_(nsockets)
+    ncores_(ncores), 
+    nsocket_(nsockets),
+    os_(os)
   {
   }
 

--- a/sstmac/software/process/compute_scheduler.h
+++ b/sstmac/software/process/compute_scheduler.h
@@ -65,7 +65,7 @@ class ComputeScheduler
   SST_ELI_DECLARE_DEFAULT_INFO()
   SST_ELI_DECLARE_CTOR(SST::Params&,sw::OperatingSystem*, int/*ncores*/, int/*nsockets*/)
 
-  ComputeScheduler(SST::Params& params, sw::OperatingSystem* os,
+  ComputeScheduler(SST::Params&  /*params*/, sw::OperatingSystem* os,
                     int ncores, int nsockets) :
     ncores_(ncores), 
     nsocket_(nsockets),

--- a/sstmac/software/process/cpuset_compute_scheduler.h
+++ b/sstmac/software/process/cpuset_compute_scheduler.h
@@ -63,8 +63,8 @@ class CpusetComputeScheduler : public ComputeScheduler
 
   CpusetComputeScheduler(SST::Params& params,
                            OperatingSystem* os, int ncore, int nsockets) :
-    available_cores_(0),
-    ComputeScheduler(params, os, ncore, nsockets)
+    ComputeScheduler(params, os, ncore, nsockets),
+    available_cores_(0)
   {
     //all cores greater than ncore should be removed from bitmask
     for (int i=0; i < ncore; ++i){

--- a/sstmac/software/process/global.cc
+++ b/sstmac/software/process/global.cc
@@ -94,7 +94,7 @@ GlobalVariableContext::registerInitFxn(int offset, std::function<void (void *)> 
 }
 
 int
-GlobalVariableContext::append(const int size, const char* name)
+GlobalVariableContext::append(const int size, const char*  /*name*/)
 {
   int offset = stackOffset;
 

--- a/sstmac/software/process/graphviz.cc
+++ b/sstmac/software/process/graphviz.cc
@@ -292,7 +292,7 @@ CallGraphOutput::dumpSummary(CallGraph* cgr)
 }
 
 void
-CallGraphOutput::output(StatisticBase *statistic, bool endOfSimFlag)
+CallGraphOutput::output(StatisticBase *statistic, bool  /*endOfSimFlag*/)
 {
   CallGraph* cgr = dynamic_cast<CallGraph*>(statistic);
   if (!cgr){

--- a/sstmac/software/process/graphviz.h
+++ b/sstmac/software/process/graphviz.h
@@ -75,7 +75,10 @@ class CallGraph : public SST::Statistics::CustomStatistic
     uint64_t self_time_ticks_;
 
    public:
-    FunctionTrace(int nfxn) : self_time_ticks_(0), calls_(nfxn) {}
+    FunctionTrace(int nfxn) : 
+      calls_(nfxn),
+      self_time_ticks_(0)
+    {}
 
     uint64_t selfTime() const {
       return self_time_ticks_;

--- a/sstmac/software/process/operating_system.cc
+++ b/sstmac/software/process/operating_system.cc
@@ -312,13 +312,13 @@ std::map<std::string,std::unique_ptr<OperatingSystem::RegressionModel>> Operatin
 std::unique_ptr<std::map<std::string,std::string>> OperatingSystem::memoize_init_ = nullptr;
 
 OperatingSystem::OperatingSystem(SST::Component* parent, SST::Params& params) :
-  node_(safe_cast(hw::Node,parent)),
-  blocked_thread_(nullptr),
-  active_thread_(nullptr),
-  des_context_(nullptr),
-  compute_sched_(nullptr),
   SubComponent("os", parent),
+  node_(safe_cast(hw::Node,parent)),
+  active_thread_(nullptr),
+  blocked_thread_(nullptr),
+  des_context_(nullptr),
   params_(params),
+  compute_sched_(nullptr),
   sync_tunnel_(nullptr)
 {
   my_addr_ = node_ ? node_->addr() : 0;
@@ -506,7 +506,7 @@ void
 OperatingSystem::compute(TimeDelta t)
 {
   // guard the ftq tag in this function
-  const auto& cur_tag = active_thread_->tag();
+  // TODOWARNING const auto& cur_tag = active_thread_->tag();
   FTQScope scope(active_thread_, FTQTag::compute);
 
   sw::UnblockEvent* ev = new sw::UnblockEvent(this, active_thread_);

--- a/sstmac/software/process/operating_system.cc
+++ b/sstmac/software/process/operating_system.cc
@@ -163,11 +163,11 @@ struct NullRegression : public OperatingSystem::ThreadSafeTimerModel<double>
   using Parent = OperatingSystem::ThreadSafeTimerModel<double>;
 
   NullRegression(SST::BaseComponent* comp, const std::string& key,
-                 const std::string& subName, SST::Params& params)
+                 const std::string&  /*subName*/, SST::Params& params)
     : Parent(params, comp, key, ""), computed_(false) {}
 
-  double compute(int n_params, const double params[],
-                 OperatingSystem::ImplicitState* state) override {
+  double compute(int  /*n_params*/, const double  /*params*/[],
+                 OperatingSystem::ImplicitState*  /*state*/) override {
     if (!computed_){
       computed_ = true;
       computeMean();
@@ -179,8 +179,8 @@ struct NullRegression : public OperatingSystem::ThreadSafeTimerModel<double>
     return Parent::start();
   }
 
-  void finishCollection(int thr_tag, int n_params, const double params[],
-                         OperatingSystem::ImplicitState* state) override {
+  void finishCollection(int thr_tag, int  /*n_params*/, const double  /*params*/[],
+                         OperatingSystem::ImplicitState*  /*state*/) override {
     Parent::finish(thr_tag);
   }
 
@@ -223,11 +223,11 @@ struct LinearRegression : public OperatingSystem::ThreadSafeTimerModel<std::pair
 
   using parent = OperatingSystem::ThreadSafeTimerModel<std::pair<double,double>>;
   LinearRegression(SST::BaseComponent* comp, const std::string& key,
-                   const std::string& subName, SST::Params& params)
+                   const std::string&  /*subName*/, SST::Params& params)
     : parent(params, comp, key, ""), computed_(false) {}
 
   double compute(int n_params, const double params[],
-                 OperatingSystem::ImplicitState* state) override {
+                 OperatingSystem::ImplicitState*  /*state*/) override {
     if (n_params != 1){
       spkt_abort_printf("linear regression can only take one parameter - got %d", n_params);
     }
@@ -245,7 +245,7 @@ struct LinearRegression : public OperatingSystem::ThreadSafeTimerModel<std::pair
   }
 
   void finishCollection(int thr_tag, int n_params, const double params[],
-                        OperatingSystem::ImplicitState* state) override {
+                        OperatingSystem::ImplicitState*  /*state*/) override {
     if (n_params != 1){
       spkt_abort_printf("linear regression can only take one parameter - got %d", n_params);
     }
@@ -987,7 +987,7 @@ OperatingSystem::startThread(Thread* t)
 }
 
 void
-OperatingSystem::startApp(App* theapp, const std::string& unique_name)
+OperatingSystem::startApp(App* theapp, const std::string&  /*unique_name*/)
 {
   os_debug("starting app %d:%d on thread %d",
     int(theapp->tid()), int(theapp->aid()), threadId());

--- a/sstmac/software/process/operating_system.h
+++ b/sstmac/software/process/operating_system.h
@@ -162,7 +162,8 @@ class OperatingSystem : public SubComponent
     ThreadSafeTimerModel(SST::Params& params, SST::BaseComponent* comp,
                          const std::string& name, const std::string& subName) :
       RegressionModel(comp, name, subName, params),
-      free_slots_(100), timers_(100)
+      timers_(100),
+      free_slots_(100)
     {
       for (int i=0; i < free_slots_.size(); ++i) free_slots_[i] = i;
     }
@@ -455,7 +456,8 @@ class OperatingSystem : public SubComponent
 
   struct CoreAllocateGuard {
     CoreAllocateGuard(OperatingSystem* os, Thread* thr) :
-      thr_(thr), os_(os)
+      os_(os),
+      thr_(thr)
     {
       os->allocateCore(thr);
     }
@@ -470,7 +472,7 @@ class OperatingSystem : public SubComponent
 
 
  private:
-  friend class CoreAllocateGuard;
+  friend struct CoreAllocateGuard;
   void allocateCore(Thread* thr);
   void deallocateCore(Thread* thr);
 

--- a/sstmac/software/process/simple_compute_scheduler.h
+++ b/sstmac/software/process/simple_compute_scheduler.h
@@ -63,7 +63,8 @@ class SimpleComputeScheduler : public ComputeScheduler
 
   SimpleComputeScheduler(SST::Params& params, OperatingSystem* os,
                          int ncore, int nsocket)
-    : ncore_active_(0), ComputeScheduler(params, os, ncore, nsocket)
+    : ComputeScheduler(params, os, ncore, nsocket),
+      ncore_active_(0) 
   {}
   
   void reserveCores(int ncore, Thread* thr) override;

--- a/sstmac/software/process/thread.cc
+++ b/sstmac/software/process/thread.cc
@@ -172,26 +172,26 @@ Thread::runRoutine(void* threadptr)
 }
 
 Thread::Thread(SST::Params& params, SoftwareId sid, OperatingSystem* os) :
-  os_(os),
   state_(PENDING),
-  bt_nfxn_(0),
-  last_bt_collect_nfxn_(0),
-  thread_id_(Thread::main_thread),
+  os_(os),
+  parent_app_(nullptr),
   p_txt_(ProcessContext::none),
+  ftag_(FTQTag::null),
+  sid_(sid),
+  host_timer_(nullptr),
+  last_bt_collect_nfxn_(0),
+  bt_nfxn_(0),
+  timed_out_(false),
+  tls_storage_(nullptr),
+  thread_id_(Thread::main_thread),
   context_(nullptr),
   cpumask_(0),
-  host_timer_(nullptr),
-  parent_app_(nullptr),
-  timed_out_(false),
+  active_core_mask_(0),
   block_counter_(0),
   pthread_concurrency_(0),
-  callGraph_(nullptr),
-  ftq_trace_(nullptr),
-  sid_(sid),
-  ftag_(FTQTag::null),
-  tls_storage_(nullptr),
   detach_state_(DETACHED),
-  active_core_mask_(0)
+  callGraph_(nullptr),
+  ftq_trace_(nullptr)
 {
   //make all cores possible active
   cpumask_ = ~(cpumask_);

--- a/sstmac/software/process/thread.cc
+++ b/sstmac/software/process/thread.cc
@@ -74,7 +74,7 @@ static thread_safe_u32 THREAD_ID_CNT(0);
 // Private method that gets called by the scheduler.
 //
 void
-Thread::initThread(const SST::Params& params,
+Thread::initThread(const SST::Params&  /*params*/,
   int physical_thread_id, ThreadContext* des_thread, void *stack,
   int stacksize, void* globals_storage, void* tls_storage)
 {
@@ -265,7 +265,7 @@ Thread::setTlsValue(long thekey, void *ptr)
 }
 
 void
-Thread::appendBacktrace(int id)
+Thread::appendBacktrace(int  /*id*/)
 {
 #if SSTMAC_HAVE_CALL_GRAPH
   backtrace_[bt_nfxn_] = id;

--- a/sstmac/software/process/time.cc
+++ b/sstmac/software/process/time.cc
@@ -63,7 +63,7 @@ extern "C" int SSTMAC_gettimeofday(struct timeval* tv, struct timezone* tz)
 extern "C" int SSTMAC_clock_gettime(clockid_t id, struct timespec *ts)
 {
   OperatingSystem* os = OperatingSystem::currentOs();
-  Timestamp t = os->now();
+  // TODOWARNING Timestamp t = os->now();
   uint64_t nsecs = os->now().nsecRounded();
   ts->tv_sec =  nsecs / 1000000000;
   ts->tv_nsec = nsecs % 1000000000;

--- a/sstmac/software/process/time.cc
+++ b/sstmac/software/process/time.cc
@@ -51,7 +51,7 @@ using sstmac::sw::OperatingSystem;
 using sstmac::TimeDelta;
 using sstmac::Timestamp;
 
-extern "C" int SSTMAC_gettimeofday(struct timeval* tv, struct timezone* tz)
+extern "C" int SSTMAC_gettimeofday(struct timeval* tv, struct timezone*  /*tz*/)
 {
   OperatingSystem* os = OperatingSystem::currentOs();
   uint64_t usecs = os->now().usecRounded();
@@ -60,7 +60,7 @@ extern "C" int SSTMAC_gettimeofday(struct timeval* tv, struct timezone* tz)
   return 0;
 }
 
-extern "C" int SSTMAC_clock_gettime(clockid_t id, struct timespec *ts)
+extern "C" int SSTMAC_clock_gettime(clockid_t  /*id*/, struct timespec *ts)
 {
   OperatingSystem* os = OperatingSystem::currentOs();
   // TODOWARNING Timestamp t = os->now();
@@ -70,7 +70,7 @@ extern "C" int SSTMAC_clock_gettime(clockid_t id, struct timespec *ts)
   return 0;
 }
 
-extern "C" int sstmac_ts_nanosleep(const struct timespec *req, struct timespec *rem)
+extern "C" int sstmac_ts_nanosleep(const struct timespec *req, struct timespec * /*rem*/)
 {
   uint64_t ticks = req->tv_sec * TimeDelta::one_second;
   ticks += req->tv_nsec * TimeDelta::one_nanosecond;

--- a/sstmac/software/threading/threading_fcontext.cc
+++ b/sstmac/software/threading/threading_fcontext.cc
@@ -67,7 +67,7 @@ class ThreadingFContext : public ThreadContext
 
   void startContext(void *stack, size_t sz,
       void (*func)(void*), void *args,
-      ThreadContext* from) override {
+      ThreadContext*  /*from*/) override {
     fxn_ = func;
     void* stacktop = (char*) stack + sz;
     ctx_ = sstmac_make_fcontext(stacktop, sz, start_fcontext_thread);
@@ -75,21 +75,21 @@ class ThreadingFContext : public ThreadContext
     ctx_ = sstmac_jump_fcontext(ctx_, this).ctx;
   }
 
-  void pauseContext(ThreadContext* to) override {
+  void pauseContext(ThreadContext*  /*to*/) override {
     // TODOWARNING ThreadingFContext* fctx = static_cast<ThreadingFContext*>(to);
     transfer_ = sstmac_jump_fcontext(transfer_, nullptr).ctx;
   }
 
-  void resumeContext(ThreadContext* from) override {
+  void resumeContext(ThreadContext*  /*from*/) override {
     auto newctx = sstmac_jump_fcontext(ctx_, nullptr).ctx;
     ctx_ = newctx;
   }
 
-  void completeContext(ThreadContext* to) override {
+  void completeContext(ThreadContext*  /*to*/) override {
     sstmac_jump_fcontext(transfer_, nullptr);
   }
 
-  void jumpContext(ThreadContext* to) override {
+  void jumpContext(ThreadContext*  /*to*/) override {
     spkt_abort_printf("error: fcontext interface does not support jump_context feature\n"
                       "must set SSTMAC_THREADING=pth or ucontext");
   }

--- a/sstmac/software/threading/threading_fcontext.cc
+++ b/sstmac/software/threading/threading_fcontext.cc
@@ -76,7 +76,7 @@ class ThreadingFContext : public ThreadContext
   }
 
   void pauseContext(ThreadContext* to) override {
-    ThreadingFContext* fctx = static_cast<ThreadingFContext*>(to);
+    // TODOWARNING ThreadingFContext* fctx = static_cast<ThreadingFContext*>(to);
     transfer_ = sstmac_jump_fcontext(transfer_, nullptr).ctx;
   }
 

--- a/sstmac/software/threading/threading_ucontext.cc
+++ b/sstmac/software/threading/threading_ucontext.cc
@@ -90,7 +90,7 @@ class ThreadingUContext : public ThreadContext
     context_.uc_stack.ss_size = stacksize;
     initContext();
 
-    ThreadingUContext* fromctx = static_cast<ThreadingUContext*>(from);
+    // TODOWARNING ThreadingUContext* fromctx = static_cast<ThreadingUContext*>(from);
     context_.uc_link = NULL;
 
     makecontext(&context_, (void

--- a/sstmac/test_skeletons/app_hello_world.cc
+++ b/sstmac/test_skeletons/app_hello_world.cc
@@ -48,7 +48,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/compute.h>
 #include <sstmac/util.h>
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
   std::string message = sstmac::getParam<std::string>("message");
   sstmac_compute(1e-6);

--- a/sstmac/test_skeletons/bw_test.cc
+++ b/sstmac/test_skeletons/bw_test.cc
@@ -50,7 +50,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #define sstmac_app_name bw_test
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
   CallGraphAppend(main);
   sumi::Transport* tport = sumi::Transport::get();

--- a/sstmac/test_skeletons/dfly_worst_case.cc
+++ b/sstmac/test_skeletons/dfly_worst_case.cc
@@ -111,7 +111,7 @@ int USER_MAIN(int argc, char** argv)
     pseudo_random_shuffle(seed, pairing);
   }
 
-  int dst_intra_grp;
+  int dst_intra_grp = 0;
   if (my_group < dst_group){
     dst_intra_grp = pairing[my_intra_grp];
   } else {

--- a/sstmac/test_skeletons/host_compute.cc
+++ b/sstmac/test_skeletons/host_compute.cc
@@ -60,7 +60,7 @@ RegisterKeywords(
 
 #define sstmac_app_name test_host_compute
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
   CallGraphAppend(main);
 

--- a/sstmac/test_skeletons/mem_bandwidth.cc
+++ b/sstmac/test_skeletons/mem_bandwidth.cc
@@ -48,7 +48,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/compute.h>
 #include <sstmac/util.h>
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
   std::vector<int> sizes = {4096, 16000, 64000, 1000000};
   for (auto sz : sizes){

--- a/sstmac/test_skeletons/mem_thrash.cc
+++ b/sstmac/test_skeletons/mem_thrash.cc
@@ -66,7 +66,8 @@ int USER_MAIN(int argc, char** argv)
 {
   MPI_Init(&argc, &argv);
 
-  int rank, size;
+  int rank; 
+  // TODOWARNING int size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   if (rank % 2 == 0){
     runPingPong();

--- a/sstmac/test_skeletons/memory_leak_test.cc
+++ b/sstmac/test_skeletons/memory_leak_test.cc
@@ -80,7 +80,7 @@ void
 test_pt2pt(MPI_Comm comm)
 {
   int rank, size;
-  int worldRank;
+  // TODOWARNING int worldRank;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
 

--- a/sstmac/test_skeletons/mpi_coverage_test.cc
+++ b/sstmac/test_skeletons/mpi_coverage_test.cc
@@ -108,7 +108,7 @@ void
 test_pt2pt(MPI_Comm comm)
 {
   int rank, size;
-  int worldRank;
+  // TODOWARNING int worldRank;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
 

--- a/sstmac/test_skeletons/sstmac_mpi_test_all.cc
+++ b/sstmac/test_skeletons/sstmac_mpi_test_all.cc
@@ -50,6 +50,8 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <math.h>
 #include <vector>
 
+#include <unusedvariablemacro.h>
+
 #define heisenbug printf("%s: %d\n", __FILE__, __LINE__); fflush(stdout)
 
 #define failure_printf(str, ...) \
@@ -72,7 +74,7 @@ static void test_scatter(MPI_Comm comm);
 
 static void test_gather(MPI_Comm comm);
 
-static void test_gatherv(MPI_Comm comm);
+// TODOWARNING static void test_gatherv(MPI_Comm comm);
 
 static void test_scan(MPI_Comm comm);
 
@@ -160,6 +162,7 @@ int USER_MAIN(int argc, char** argv)
   return 0;
 }
 
+SSTMAC_MAYBE_UNUSED
 void
 test_scan(MPI_Comm comm)
 {
@@ -308,7 +311,7 @@ test_reduce(MPI_Comm comm)
   int rank, size;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
-  int count = 100; //arbitrary
+  // TODOWARNING int count = 100; //arbitrary
 
   int var = rank;
   int root = 2 % size;
@@ -561,7 +564,8 @@ test_reducescatter(MPI_Comm comm)
 {
   // sumi does not support reduce_scatter at the moment
   // it does support reduce scatter block
-  int rank, size, recv = 0;
+  int rank, size;
+  // TODOWARNING int recv = 0;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
 

--- a/sumi-mpi/Makefile.am
+++ b/sumi-mpi/Makefile.am
@@ -17,6 +17,7 @@ library_includedir=$(includedir)/sumi-mpi
 
 AM_CPPFLAGS += \
 	-I$(top_srcdir)/sumi \
+	-I$(top_srcdir)/include \
 	-I$(top_builddir)/sumi
 
 if HAVE_OTF2

--- a/sumi-mpi/mpi_api.cc
+++ b/sumi-mpi/mpi_api.cc
@@ -117,20 +117,20 @@ MpiApi* sstmac_mpi()
 MpiApi::MpiApi(SST::Params& params, sstmac::sw::App* app,
                SST::Component* comp) :
   sumi::SimTransport(params, app, comp),
-  status_(is_fresh),
+  queue_(nullptr),
   next_type_id_(0),
   next_op_id_(first_custom_op_id),
-  group_counter_(MPI_GROUP_SELF+1),
+  comm_factory_(app->sid(), this),
+  status_(is_fresh),
+  crossed_comm_world_barrier_(false),
   worldcomm_(nullptr),
   selfcomm_(nullptr),
-  req_counter_(0),
-  queue_(nullptr),
-  generate_ids_(true),
+  group_counter_(MPI_GROUP_SELF+1),
 #ifdef SSTMAC_OTF2_ENABLED
   OTF2Writer_(nullptr),
 #endif
-  crossed_comm_world_barrier_(false),
-  comm_factory_(app->sid(), this)
+  req_counter_(0),
+  generate_ids_(true)
 {
   if (!engine_) engine_ = new CollectiveEngine(params, this);
 
@@ -222,7 +222,9 @@ MpiApi::commRank(MPI_Comm comm, int *rank)
 int
 MpiApi::init(int* argc, char*** argv)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   if (status_ == is_initialized){
     sprockit::abort("MPI_Init cannot be called twice");
@@ -282,7 +284,9 @@ MpiApi::checkInit()
 int
 MpiApi::finalize()
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   StartMPICall(MPI_Finalize);
 
@@ -320,7 +324,7 @@ MpiApi::finalize()
 double
 MpiApi::wtime()
 {
-  auto call_start_time = (uint64_t)now().usec();
+  // TODOWARNING auto call_start_time = (uint64_t)now().usec();
   StartMPICall(MPI_Wtime);
   return now().sec();
 }
@@ -328,7 +332,7 @@ MpiApi::wtime()
 int
 MpiApi::getCount(const MPI_Status *status, MPI_Datatype datatype, int *count)
 {
-  auto call_start_time = (uint64_t)now().usec();
+  // TODOWARNING auto call_start_time = (uint64_t)now().usec();
   *count = status->count;
   return MPI_SUCCESS;
 }

--- a/sumi-mpi/mpi_api.cc
+++ b/sumi-mpi/mpi_api.cc
@@ -204,7 +204,7 @@ MpiApi::~MpiApi()
 }
 
 int
-MpiApi::abort(MPI_Comm comm, int errcode)
+MpiApi::abort(MPI_Comm  /*comm*/, int errcode)
 {
 
   spkt_throw_printf(sprockit::ValueError,
@@ -220,7 +220,7 @@ MpiApi::commRank(MPI_Comm comm, int *rank)
 }
 
 int
-MpiApi::init(int* argc, char*** argv)
+MpiApi::init(int*  /*argc*/, char***  /*argv*/)
 {
 #ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
@@ -330,7 +330,7 @@ MpiApi::wtime()
 }
 
 int
-MpiApi::getCount(const MPI_Status *status, MPI_Datatype datatype, int *count)
+MpiApi::getCount(const MPI_Status *status, MPI_Datatype  /*datatype*/, int *count)
 {
   // TODOWARNING auto call_start_time = (uint64_t)now().usec();
   *count = status->count;
@@ -581,7 +581,7 @@ MpiApi::checkKey(int key)
 
 
 int
-MpiApi::errorString(int errorcode, char *str, int *resultlen)
+MpiApi::errorString(int  /*errorcode*/, char *str, int *resultlen)
 {
   static const char* errorstr = "mpi error";
   *resultlen = ::strlen(errorstr);

--- a/sumi-mpi/mpi_api.h
+++ b/sumi-mpi/mpi_api.h
@@ -139,11 +139,11 @@ class MpiApi : public sumi::SimTransport
     return MPI_SUCCESS;
   }
 
-  int bufferAttach(void* buffer, int size){
+  int bufferAttach(void*  /*buffer*/, int  /*size*/){
     return MPI_SUCCESS;
   }
 
-  int bufferDetach(void* buffer, int* size){
+  int bufferDetach(void*  /*buffer*/, int*  /*size*/){
     return MPI_SUCCESS;
   }
 
@@ -170,15 +170,15 @@ class MpiApi : public sumi::SimTransport
 
   int abort(MPI_Comm comm, int errcode);
 
-  int errhandlerSet(MPI_Comm comm, MPI_Errhandler handler){
+  int errhandlerSet(MPI_Comm  /*comm*/, MPI_Errhandler  /*handler*/){
     return MPI_SUCCESS;
   }
 
-  int errhandlerCreate(MPI_Handler_function *function, MPI_Errhandler *errhandler){
+  int errhandlerCreate(MPI_Handler_function * /*function*/, MPI_Errhandler * /*errhandler*/){
     return MPI_SUCCESS;
   }
 
-  int errorClass(int errorcode, int* errorclass){
+  int errorClass(int  /*errorcode*/, int* errorclass){
     *errorclass = 0;
     return MPI_SUCCESS;
   }
@@ -221,7 +221,7 @@ class MpiApi : public sumi::SimTransport
 
   int commFree(MPI_Comm* input);
 
-  int commSetErrhandler(MPI_Comm comm, MPI_Errhandler errhandler){
+  int commSetErrhandler(MPI_Comm  /*comm*/, MPI_Errhandler  /*errhandler*/){
     return MPI_SUCCESS;
   }
 

--- a/sumi-mpi/mpi_api_collectives.cc
+++ b/sumi-mpi/mpi_api_collectives.cc
@@ -842,7 +842,7 @@ MpiApi::startReduceScatter(CollectiveOp* op)
 }
 
 CollectiveOpBase::ptr
-MpiApi::startReduceScatter(const char* name, MPI_Comm comm, const int* recvcounts,
+MpiApi::startReduceScatter(const char*  /*name*/, MPI_Comm  /*comm*/, const int*  /*recvcounts*/,
                            MPI_Datatype type, MPI_Op mop, const void* src, void* dst)
 {
   sprockit::abort("sumi::reduce_scatter");
@@ -903,7 +903,7 @@ MpiApi::ireduceScatter(int *recvcnts, MPI_Datatype type,
 }
 
 CollectiveOpBase::ptr
-MpiApi::startReduceScatterBlock(const char* name, MPI_Comm comm, int count, MPI_Datatype type,
+MpiApi::startReduceScatterBlock(const char*  /*name*/, MPI_Comm  /*comm*/, int  /*count*/, MPI_Datatype type,
                                     MPI_Op mop, const void* src, void* dst)
 {
   sprockit::abort("sumi::reduce_scatter: not implemented");

--- a/sumi-mpi/mpi_api_collectives.cc
+++ b/sumi-mpi/mpi_api_collectives.cc
@@ -92,7 +92,7 @@ MpiApi::startMpiCollective(Collective::type_t ty,
   op->ty = ty;
   op->sendbuf = const_cast<void*>(sendbuf);
   op->recvbuf = recvbuf;
-  const char* name = Collective::tostr(ty);
+  // TODOWARNING const char* name = Collective::tostr(ty);
 
   if (sendbuf == MPI_IN_PLACE){
     if (recvbuf){
@@ -287,7 +287,9 @@ int
 MpiApi::allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                    void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   do_coll(Allgather, MPI_Allgather, comm,
           sendcount, sendtype, recvcount, recvtype,
@@ -357,7 +359,9 @@ MpiApi::alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
                  MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   do_coll(Alltoall, MPI_Alltoall, comm,
          sendcount, sendtype,
@@ -448,7 +452,9 @@ int
 MpiApi::allreduce(const void *src, void *dst, int count,
                    MPI_Datatype type, MPI_Op mop, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   do_coll(Allreduce, MPI_Allreduce, comm,
            count, type, mop, src, dst);
@@ -510,7 +516,10 @@ MpiApi::startBarrier(const char* name, MPI_Comm comm)
 int
 MpiApi::barrier(MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
+
   StartMPICall(MPI_Barrier);
   waitCollective( startBarrier("MPI_Barrier", comm) );
   FinishMPICall(MPI_Barrier);
@@ -578,8 +587,9 @@ MpiApi::startBcast(const char* name, MPI_Comm comm, int count, MPI_Datatype data
 int
 MpiApi::bcast(void* buffer, int count, MPI_Datatype type, int root, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
-
+#endif
   do_coll(Bcast, MPI_Bcast, comm,
            count, type, root, buffer);
 
@@ -668,8 +678,9 @@ int
 MpiApi::gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
-
+#endif
   do_coll(Gather, MPI_Gather, comm, sendcount, sendtype, root,
           recvcount, recvtype, sendbuf, recvbuf);
 
@@ -779,8 +790,9 @@ int
 MpiApi::reduce(const void *src, void *dst, int count,
                 MPI_Datatype type, MPI_Op mop, int root, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
-
+#endif
   do_coll(Reduce, MPI_Reduce, comm, count,
           type, root, mop, src, dst);
 
@@ -851,8 +863,9 @@ int
 MpiApi::reduceScatter(const void *src, void *dst, const int *recvcnts,
                         MPI_Datatype type, MPI_Op mop, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
-
+#endif
   do_coll(ReduceScatter, MPI_Reduce_scatter,
           comm, recvcnts, type, mop, src, dst);
 
@@ -976,8 +989,9 @@ MpiApi::startScan(const char* name, MPI_Comm comm, int count, MPI_Datatype type,
 int
 MpiApi::scan(const void *src, void *dst, int count, MPI_Datatype type, MPI_Op mop, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
-
+#endif
   do_coll(Scan, MPI_Scan, comm, count, type, mop, src, dst);
 
 #ifdef SSTMAC_OTF2_ENABLED
@@ -1053,8 +1067,9 @@ MpiApi::scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
                  MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
-
+#endif
   do_coll(Scatter, MPI_Scatter, comm, sendcount, sendtype, root,
           recvcount, recvtype, sendbuf, recvbuf);
 

--- a/sumi-mpi/mpi_api_comm.cc
+++ b/sumi-mpi/mpi_api_comm.cc
@@ -50,8 +50,13 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/software/process/thread.h>
 #include <sstmac/software/process/ftq_scope.h>
 
+// TODOWARNING
+// #define StartCommCall(fxn,comm) \
+//   auto call_start_time = (uint64_t)now().usec(); \
+//   StartMPICall(fxn); \
+//   mpi_api_debug(sprockit::dbg::mpi, "%s(%s) start", #fxn, commStr(comm).c_str())
+
 #define StartCommCall(fxn,comm) \
-  auto call_start_time = (uint64_t)now().usec(); \
   StartMPICall(fxn); \
   mpi_api_debug(sprockit::dbg::mpi, "%s(%s) start", #fxn, commStr(comm).c_str())
 
@@ -61,7 +66,10 @@ int
 MpiApi::commDup(MPI_Comm input, MPI_Comm *output)
 {
   checkInit();
+
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
   StartCommCall(MPI_Comm_dup,input);
   MpiComm* inputPtr = getComm(input);
   MpiComm* outputPtr = comm_factory_.comm_dup(inputPtr);
@@ -113,7 +121,9 @@ MpiApi::commSize(MPI_Comm comm, int *size)
 int
 MpiApi::commCreate(MPI_Comm input, MPI_Group group, MPI_Comm *output)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
   StartCommCall(MPI_Comm_create,input);
   MpiComm* inputPtr = getComm(input);
   MpiGroup* groupPtr = getGroup(group);
@@ -250,7 +260,9 @@ MpiApi::cartCoords(MPI_Comm comm, int rank, int maxdims, int coords[])
 int
 MpiApi::commSplit(MPI_Comm incomm, int color, int key, MPI_Comm *outcomm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
   StartCommCall(MPI_Comm_split,incomm);
   MpiComm* incommPtr = getComm(incomm);
   MpiComm* outcommPtr = comm_factory_.commSplit(incommPtr, color, key);

--- a/sumi-mpi/mpi_api_comm.cc
+++ b/sumi-mpi/mpi_api_comm.cc
@@ -89,7 +89,7 @@ MpiApi::commDup(MPI_Comm input, MPI_Comm *output)
 }
 
 int
-MpiApi::commCreateGroup(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *newcomm)
+MpiApi::commCreateGroup(MPI_Comm comm, MPI_Group group, int  /*tag*/, MPI_Comm *newcomm)
 {
   checkInit();
   StartCommCall(MPI_Comm_create_group,comm);
@@ -245,7 +245,7 @@ MpiApi::cartShift(MPI_Comm comm, int direction, int disp, int *rank_source,
 }
 
 int
-MpiApi::cartCoords(MPI_Comm comm, int rank, int maxdims, int coords[])
+MpiApi::cartCoords(MPI_Comm comm, int rank, int  /*maxdims*/, int coords[])
 {
   mpi_api_debug(sprockit::dbg::mpi, "MPI_Cart_coords(...)");
   MpiComm* incommPtr = getComm(comm);
@@ -317,7 +317,7 @@ MpiApi::commFree(MPI_Comm* input)
 }
 
 int
-MpiApi::commGetAttr(MPI_Comm, int comm_keyval, void* attribute_val, int *flag)
+MpiApi::commGetAttr(MPI_Comm, int  /*comm_keyval*/, void*  /*attribute_val*/, int *flag)
 {
   /**
   if (comm_keyval == MPI_TAG_UB){

--- a/sumi-mpi/mpi_api_send_recv.cc
+++ b/sumi-mpi/mpi_api_send_recv.cc
@@ -65,7 +65,9 @@ namespace sumi {
 int
 MpiApi::send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm)
 {  
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   start_pt2pt_call(MPI_Send,count,datatype,dest,tag,comm);
   MpiComm* commPtr = getComm(comm);
@@ -92,7 +94,9 @@ MpiApi::sendrecv(const void *sendbuf, int sendcount,
  MPI_Datatype recvtype, int source, int recvtag,
  MPI_Comm comm, MPI_Status *status)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   start_pt2pt_call(MPI_Sendrecv,sendcount,sendtype,source,recvtag,comm);
   MpiRequest* req = doIsend(sendbuf, sendcount, sendtype, dest, sendtag, comm);
@@ -116,7 +120,9 @@ MpiApi::request_free(MPI_Request *req)
   mpi_api_debug(sprockit::dbg::mpi | sprockit::dbg::mpi_request | sprockit::dbg::mpi_pt2pt,
     "MPI_Request_free(REQ=%d)", *req);
 
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   MpiRequest* reqPtr = getRequest(*req);
   if (reqPtr){
@@ -162,7 +168,9 @@ MpiApi::doStart(MPI_Request req)
 int
 MpiApi::start(MPI_Request* req)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   _StartMPICall_(MPI_Start);
   doStart(*req);
@@ -179,7 +187,7 @@ MpiApi::start(MPI_Request* req)
 int
 MpiApi::startall(int count, MPI_Request* req)
 {
-  auto call_start_time = (uint64_t)now().usec();
+  // TODOWARNING auto call_start_time = (uint64_t)now().usec();
 
   _StartMPICall_(MPI_Startall);
   for (int i=0; i < count; ++i){
@@ -201,7 +209,7 @@ MpiApi::sendInit(const void *buf, int count,
                  MPI_Datatype datatype, int dest, int tag,
                  MPI_Comm comm, MPI_Request *request)
 {
-  auto call_start_time = (uint64_t)now().usec();
+  // TODOWARNING auto call_start_time = (uint64_t)now().usec();
 
   _StartMPICall_(MPI_Send_init);
 
@@ -249,7 +257,9 @@ int
 MpiApi::isend(const void *buf, int count, MPI_Datatype datatype, int dest,
                int tag, MPI_Comm comm, MPI_Request *request)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   start_Ipt2pt_call(MPI_Isend,count,datatype,dest,tag,comm,request);
   MpiRequest* req = doIsend(buf, count, datatype, dest, tag, comm);
@@ -275,7 +285,9 @@ int
 MpiApi::recv(void *buf, int count, MPI_Datatype datatype, int source,
               int tag, MPI_Comm comm, MPI_Status *status)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   start_pt2pt_call(MPI_Recv,count,datatype,source,tag,comm);
   int rc = doRecv(buf,count,datatype,source,tag,comm,status);
@@ -344,7 +356,9 @@ int
 MpiApi::irecv(void *buf, int count, MPI_Datatype datatype, int source,
                int tag, MPI_Comm comm, MPI_Request *request)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   start_Ipt2pt_call(MPI_Irecv,count,datatype,dest,tag,comm,request);
 

--- a/sumi-mpi/mpi_api_test.cc
+++ b/sumi-mpi/mpi_api_test.cc
@@ -82,8 +82,10 @@ MpiApi::test(MPI_Request *request, MPI_Status *status, int& tag, int& source)
 int
 MpiApi::test(MPI_Request *request, int *flag, MPI_Status *status)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   MPI_Request req_cpy = *request;
   auto start_clock = traceClock();
+#endif
   int tag, source;
   _StartMPICall_(MPI_Test);
   if (test(request, status, tag, source)){

--- a/sumi-mpi/mpi_api_type.cc
+++ b/sumi-mpi/mpi_api_type.cc
@@ -251,7 +251,7 @@ MpiApi::commitBuiltinTypes()
 }
 
 int
-MpiApi::packSize(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size)
+MpiApi::packSize(int incount, MPI_Datatype datatype, MPI_Comm  /*comm*/, int *size)
 {
   auto it = known_types_.find(datatype);
   if (it == known_types_.end()){

--- a/sumi-mpi/mpi_api_vcollectives.cc
+++ b/sumi-mpi/mpi_api_vcollectives.cc
@@ -260,11 +260,11 @@ MpiApi::ialltoallv(const int *sendcounts, MPI_Datatype sendtype,
 }
 
 int
-MpiApi::ialltoallw(const void *sendbuf, const int sendcounts[],
-                    const int sdispls[], const MPI_Datatype sendtypes[],
-                    void *recvbuf, const int recvcounts[],
-                    const int rdispls[], const MPI_Datatype recvtypes[],
-                    MPI_Comm comm, MPI_Request *request)
+MpiApi::ialltoallw(const void * /*sendbuf*/, const int  /*sendcounts*/[],
+                    const int  /*sdispls*/[], const MPI_Datatype  /*sendtypes*/[],
+                    void * /*recvbuf*/, const int  /*recvcounts*/[],
+                    const int  /*rdispls*/[], const MPI_Datatype  /*recvtypes*/[],
+                    MPI_Comm  /*comm*/, MPI_Request * /*request*/)
 {
   sprockit::abort("MPI_Ialltoallw: unimplemented"
                   "but, seriously, why are you using this collective anyway?");
@@ -272,7 +272,7 @@ MpiApi::ialltoallw(const void *sendbuf, const int sendcounts[],
 }
 
 sumi::CollectiveDoneMessage*
-MpiApi::startGatherv(CollectivevOp* op)
+MpiApi::startGatherv(CollectivevOp*  /*op*/)
 {
   sprockit::abort("sumi::gatherv: not implemented");
   return nullptr;
@@ -379,7 +379,7 @@ MpiApi::igatherv(int sendcount, MPI_Datatype sendtype,
 }
 
 sumi::CollectiveDoneMessage*
-MpiApi::startScatterv(CollectivevOp* op)
+MpiApi::startScatterv(CollectivevOp*  /*op*/)
 {
   sprockit::abort("sumi::scatterv: not implemented");
   return nullptr;

--- a/sumi-mpi/mpi_api_vcollectives.cc
+++ b/sumi-mpi/mpi_api_vcollectives.cc
@@ -115,7 +115,9 @@ MpiApi::allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                     void *recvbuf, const int *recvcounts, const int *displs,
                     MPI_Datatype recvtype, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   do_vcoll(Allgatherv, MPI_Allgatherv, comm, sendcount, sendtype,
            recvcounts, displs, recvtype, sendbuf, recvbuf);
@@ -208,7 +210,9 @@ MpiApi::alltoallv(const void *sendbuf, const int *sendcounts,
                    void *recvbuf, const int *recvcounts,
                    const int *rdispls, MPI_Datatype recvtype, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   do_vcoll(Alltoallv, MPI_Alltoallv, comm,
            sendcounts, sendtype, sdispls,
@@ -320,7 +324,7 @@ MpiApi::startGatherv(const char* name, MPI_Comm comm, int sendcount, MPI_Datatyp
     }
     auto op = startGather(name, comm, sendcount, sendtype, root, recvcount, recvtype,
                           sendbuf, recvbuf);
-    return std::move(op);
+    return op;
   }
 }
 
@@ -329,7 +333,9 @@ MpiApi::gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                  void *recvbuf, const int *recvcounts, const int *displs,
                  MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   do_vcoll(Gatherv, MPI_Gatherv, comm, sendcount, sendtype, root,
            recvcounts, displs, recvtype, sendbuf, recvbuf);
@@ -431,7 +437,9 @@ int
 MpiApi::scatterv(const void* sendbuf, const int* sendcounts, const int *displs, MPI_Datatype sendtype,
                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   do_vcoll(Scatterv, MPI_Scatterv, comm, sendcounts, sendtype, root, displs,
            recvcount, recvtype, sendbuf, recvbuf);

--- a/sumi-mpi/mpi_api_wait.cc
+++ b/sumi-mpi/mpi_api_wait.cc
@@ -161,7 +161,9 @@ int
 MpiApi::waitany(int count, MPI_Request array_of_requests[], int *indx,
                  MPI_Status *status)
 {
+#ifdef SSTMAC_OTF2_ENABLED
   auto start_clock = traceClock();
+#endif
 
   // for caching the request in an upper scope before it is destroyed
   MPI_Request req_val = -1;

--- a/sumi-mpi/mpi_api_win.cc
+++ b/sumi-mpi/mpi_api_win.cc
@@ -48,61 +48,61 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace sumi {
 
 int
-MpiApi::winFlush(int rank, MPI_Win win)
+MpiApi::winFlush(int  /*rank*/, MPI_Win  /*win*/)
 {
   spkt_abort_printf("unimplemented error: MPI_Win_flush");
   return MPI_SUCCESS;
 }
 
 int
-MpiApi::winFlushLocal(int rank, MPI_Win win)
+MpiApi::winFlushLocal(int  /*rank*/, MPI_Win  /*win*/)
 {
   spkt_abort_printf("unimplemented error: MPI_Win_flush_local");
   return MPI_SUCCESS;
 }
 
 int
-MpiApi::winCreate(void *base, MPI_Aint size, int disp_unit, MPI_Info info,
-               MPI_Comm comm, MPI_Win *win)
+MpiApi::winCreate(void * /*base*/, MPI_Aint  /*size*/, int  /*disp_unit*/, MPI_Info  /*info*/,
+               MPI_Comm  /*comm*/, MPI_Win * /*win*/)
 {
   spkt_abort_printf("unimplemented error: MPI_Win_flush_local");
   return MPI_SUCCESS;
 }
 
 int
-MpiApi::winFree(MPI_Win *win)
+MpiApi::winFree(MPI_Win * /*win*/)
 {
   spkt_abort_printf("unimplemented error: MPI_Win_flush_local");
   return MPI_SUCCESS;
 }
 
 int
-MpiApi::winLock(int lock_type, int rank, int assert, MPI_Win win)
+MpiApi::winLock(int  /*lock_type*/, int  /*rank*/, int  /*assert*/, MPI_Win  /*win*/)
 {
   spkt_abort_printf("unimplemented error: MPI_Win_flush_local");
   return MPI_SUCCESS;
 }
 
 int
-MpiApi::winUnlock(int rank, MPI_Win win)
+MpiApi::winUnlock(int  /*rank*/, MPI_Win  /*win*/)
 {
   spkt_abort_printf("unimplemented error: MPI_Win_flush_local");
   return MPI_SUCCESS;
 }
 
 int
-MpiApi::get(void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
-             int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype,
-             MPI_Win win)
+MpiApi::get(void * /*origin_addr*/, int  /*origin_count*/, MPI_Datatype  /*origin_datatype*/,
+             int  /*target_rank*/, MPI_Aint  /*target_disp*/, int  /*target_count*/, MPI_Datatype  /*target_datatype*/,
+             MPI_Win  /*win*/)
 {
   spkt_abort_printf("unimplemented error: MPI_Get");
   return MPI_SUCCESS;
 }
 
 int
-MpiApi::put(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
-             int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype,
-             MPI_Win win)
+MpiApi::put(const void * /*origin_addr*/, int  /*origin_count*/, MPI_Datatype  /*origin_datatype*/,
+             int  /*target_rank*/, MPI_Aint  /*target_disp*/, int  /*target_count*/, MPI_Datatype  /*target_datatype*/,
+             MPI_Win  /*win*/)
 {
   spkt_abort_printf("unimplemented error: MPI_Put");
   return MPI_SUCCESS;

--- a/sumi-mpi/mpi_comm/mpi_comm.cc
+++ b/sumi-mpi/mpi_comm/mpi_comm.cc
@@ -55,13 +55,13 @@ namespace sumi {
 MpiComm* MpiComm::comm_null = nullptr;
 
 MpiComm::MpiComm() :
+  Communicator(-1),
   group_(nullptr),
   next_collective_tag_(0),
-  id_(MPI_COMM_NULL),
-  rank_(-1),
   del_grp_(false),
-  Communicator(-1),
-  topotype_(TOPO_NONE)
+  topotype_(TOPO_NONE),
+  id_(MPI_COMM_NULL),
+  rank_(-1)
 {
 }
 
@@ -80,10 +80,10 @@ MpiComm::MpiComm(
   group_(peers),
   next_collective_tag_(MPI_COMM_WORLD + 100),
   aid_(aid),
-  id_(id),
-  rank_(rank),
   del_grp_(del_grp),
-  topotype_(ty)
+  topotype_(ty),
+  id_(id),
+  rank_(rank)
 {
   if (peers->size() == 0) {
     spkt_throw_printf(sprockit::ValueError,

--- a/sumi-mpi/mpi_comm/mpi_comm.cc
+++ b/sumi-mpi/mpi_comm/mpi_comm.cc
@@ -132,7 +132,7 @@ MpiComm::deleteStatics()
 }
 
 int
-MpiComm::globalToCommRank(int global_rank) const
+MpiComm::globalToCommRank(int  /*global_rank*/) const
 {
   sprockit::abort("mpi_comm::global_to_comm_rank");
   return 0;

--- a/sumi-mpi/mpi_comm/mpi_comm_factory.cc
+++ b/sumi-mpi/mpi_comm/mpi_comm_factory.cc
@@ -51,6 +51,8 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sprockit/errors.h>
 #include <sprockit/stl_string.h>
 
+#include <unusedvariablemacro.h>
+
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -216,11 +218,11 @@ MpiCommFactory::commSplit(MpiComm* caller, int my_color, int my_key)
   int root = caller->peerTask(int(0));
   int tag = caller->nextCollectiveTag();
   comm_split_entry& entry = comm_split_entries[aid][int(caller->id())][root][tag];
-  char fname[256];
-  size_t len = 3*caller->size()*sizeof(int);
   entry.refcount++;
   if (entry.buf == 0){
 #if SSTMAC_MMAP_COLLECTIVES
+    char fname[256];
+    size_t len = 3*caller->size()*sizeof(int);
     sprintf(fname, "%d.%d.%d", int(caller->id()), root, tag);
     int fd = shm_open(fname, O_RDWR | O_CREAT | O_EXCL, S_IRWXU);
     if (fd < 0){ //oops, someone else already created it

--- a/sumi-mpi/mpi_comm/mpi_group.cc
+++ b/sumi-mpi/mpi_comm/mpi_group.cc
@@ -51,8 +51,8 @@ namespace sumi {
 
 MpiGroup::MpiGroup(const std::vector<TaskId>& tl) :
   local_to_world_map_(tl),
-  is_comm_world_(false),
-  size_(tl.size())
+  size_(tl.size()),
+  is_comm_world_(false)
 {
 }
 

--- a/sumi-mpi/mpi_delay_stats.cc
+++ b/sumi-mpi/mpi_delay_stats.cc
@@ -23,13 +23,13 @@ DelayStats::addData_impl(int src, int dst, int type, int stage, uint64_t bytes,
 }
 
 void
-DelayStats::registerOutputFields(SST::Statistics::StatisticFieldsOutput *statOutput)
+DelayStats::registerOutputFields(SST::Statistics::StatisticFieldsOutput * /*statOutput*/)
 {
   sprockit::abort("DelayStats::registerOutputFields: should not be called");
 }
 
 void
-DelayStats::outputStatisticData(SST::Statistics::StatisticFieldsOutput *output, bool endOfSimFlag)
+DelayStats::outputStatisticData(SST::Statistics::StatisticFieldsOutput * /*output*/, bool  /*endOfSimFlag*/)
 {
   sprockit::abort("DelayStats::outputStatisticData: should not be called");
 }
@@ -54,7 +54,7 @@ DelayStatsOutput::stopOutputGroup()
 }
 
 void
-DelayStatsOutput::output(SST::Statistics::StatisticBase* statistic, bool endOfSimFlag)
+DelayStatsOutput::output(SST::Statistics::StatisticBase* statistic, bool  /*endOfSimFlag*/)
 {
   DelayStats* stats = dynamic_cast<DelayStats*>(statistic);
   for (auto iter=stats->begin(); iter != stats->end(); ++iter){

--- a/sumi-mpi/mpi_protocol/eager0.cc
+++ b/sumi-mpi/mpi_protocol/eager0.cc
@@ -50,6 +50,8 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/null_buffer.h>
 #include <sprockit/sim_parameters.h>
 
+#include <unusedvariablemacro.h>
+
 namespace sumi {
 
 Eager0::Eager0(SST::Params &params, MpiQueue *queue) :
@@ -62,7 +64,7 @@ void
 Eager0::start(void* buffer, int src_rank, int dst_rank, sstmac::sw::TaskId tid, int count, MpiType* typeobj,
               int tag, MPI_Comm comm, int seq_id, MpiRequest* req)
 {
-  CallGraphAppend(MPIEager0Protocol_Send_Header);
+  SSTMAC_MAYBE_UNUSED CallGraphAppend(MPIEager0Protocol_Send_Header);
   void* temp_buf = nullptr;
   if (isNonNullBuffer(buffer)){
     temp_buf = fillSendBuffer(count, buffer, typeobj);
@@ -99,7 +101,7 @@ Eager0::incoming(MpiMessage *msg, MpiQueueRecvRequest *req)
 void
 Eager0::incoming(MpiMessage* msg)
 {
-  CallGraphAppend(MPIEager0Protocol_Handle_Header);
+  SSTMAC_MAYBE_UNUSED CallGraphAppend(MPIEager0Protocol_Handle_Header);
   if (msg->sstmac::hw::NetworkMessage::type() == MpiMessage::payload_sent_ack){
     char* temp_buf = (char*) msg->smsgBuffer();
     if (temp_buf) delete[] temp_buf;

--- a/sumi-mpi/mpi_protocol/mpi_protocol.cc
+++ b/sumi-mpi/mpi_protocol/mpi_protocol.cc
@@ -50,7 +50,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 namespace sumi {
 
-MpiProtocol::MpiProtocol(SST::Params& params, MpiQueue *queue) :
+MpiProtocol::MpiProtocol(SST::Params&  /*params*/, MpiQueue *queue) :
   queue_(queue), mpi_(queue_->api())
 {
 }

--- a/sumi-mpi/mpi_protocol/mpi_protocol.h
+++ b/sumi-mpi/mpi_protocol/mpi_protocol.h
@@ -213,7 +213,7 @@ class RendezvousGet final : public RendezvousProtocol
     MpiRequest* req;
     void* original;
     void* temporary;
-    send(MpiRequest* r, void* o, void* t) :
+    send(MpiRequest* r, void*  /*o*/, void* t) :
       req(r), original(0), temporary(t){}
   };
 

--- a/sumi-mpi/mpi_queue/mpi_queue.cc
+++ b/sumi-mpi/mpi_queue/mpi_queue.cc
@@ -51,6 +51,9 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/software/process/app.h>
 #include <sstmac/software/process/operating_system.h>
 #include <sstmac/software/process/thread.h>
+
+#include <unusedvariablemacro.h>
+
 #include <sprockit/sim_parameters.h>
 #include <sprockit/factory.h>
 #include <sprockit/debug.h>
@@ -84,9 +87,9 @@ MpiQueue::sortbyseqnum::operator()(MpiMessage* a, MpiMessage*b) const
 
 MpiQueue::MpiQueue(SST::Params& params, int task_id,
                    MpiApi* api, CollectiveEngine* engine) :
+  queue_(api->parent()->os()),
   taskid_(task_id),
-  api_(api),
-  queue_(api->parent()->os())
+  api_(api)
 {
   max_vshort_msg_size_ = params.find<SST::UnitAlgebra>("max_vshort_msg_size", "512B").getRoundedValue();
   max_eager_msg_size_ = params.find<SST::UnitAlgebra>("max_eager_msg_size", "8192B").getRoundedValue();

--- a/sumi-mpi/mpi_queue/mpi_queue.cc
+++ b/sumi-mpi/mpi_queue/mpi_queue.cc
@@ -86,7 +86,7 @@ MpiQueue::sortbyseqnum::operator()(MpiMessage* a, MpiMessage*b) const
 }
 
 MpiQueue::MpiQueue(SST::Params& params, int task_id,
-                   MpiApi* api, CollectiveEngine* engine) :
+                   MpiApi* api, CollectiveEngine*  /*engine*/) :
   queue_(api->parent()->os()),
   taskid_(task_id),
   api_(api)
@@ -507,7 +507,7 @@ MpiQueue::forwardProgress(double timeout)
 void
 MpiQueue::startProgressLoop(
   const std::vector<MpiRequest*>& req,
-  sstmac::TimeDelta timeout)
+  sstmac::TimeDelta  /*timeout*/)
 {
   startProgressLoop(req);
 }

--- a/sumi-mpi/mpi_queue/mpi_queue_recv_request.cc
+++ b/sumi-mpi/mpi_queue/mpi_queue_recv_request.cc
@@ -61,9 +61,17 @@ MpiQueueRecvRequest::MpiQueueRecvRequest(
   int count,
   MPI_Datatype type,
   int source, int tag, MPI_Comm comm, void* buffer) :
-  start_(start), queue_(queue), source_(source), tag_(tag), comm_(comm),
-  seqnum_(0), count_(count), type_(queue->api()->typeFromId(type)),
-  key_(key), final_buffer_(buffer), recv_buffer_(nullptr)
+  queue_(queue), 
+  source_(source), 
+  tag_(tag), 
+  comm_(comm),
+  seqnum_(0), 
+  final_buffer_(buffer), 
+  recv_buffer_(nullptr),
+  count_(count), 
+  type_(queue->api()->typeFromId(type)),
+  key_(key), 
+  start_(start) 
 {
   if (isNonNullBuffer(buffer) && !type_->contiguous()){
     recv_buffer_ = new char[count*type_->packed_size()];

--- a/sumi-mpi/mpi_request.cc
+++ b/sumi-mpi/mpi_request.cc
@@ -48,8 +48,11 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace sumi {
 
 CollectiveOpBase::CollectiveOpBase(MpiComm* cm) :
-  comm(cm), packed_send(false), packed_recv(false),
-  tag(cm->nextCollectiveTag()), complete(false)
+  packed_send(false), 
+  packed_recv(false),
+  tag(cm->nextCollectiveTag()), 
+  comm(cm), 
+  complete(false)
 {
 }
 

--- a/sumi-mpi/mpi_types/mpi_type.cc
+++ b/sumi-mpi/mpi_types/mpi_type.cc
@@ -145,7 +145,7 @@ MpiType::init_primitive(const char* labelit, int size)
 // MPI datatypes.
 //
 void
-MpiType::init_primitive(const std::string& labelit, const int sizeit, int align)
+MpiType::init_primitive(const std::string& labelit, const int sizeit, int  /*align*/)
 {
   // TODOWARNING init_primitive(labelit.c_str(), sizeit, align);
   init_primitive(labelit.c_str(), sizeit);

--- a/sumi-mpi/mpi_types/mpi_type.cc
+++ b/sumi-mpi/mpi_types/mpi_type.cc
@@ -57,14 +57,14 @@ namespace sumi {
 
 MpiType::MpiType() :
   id(-1),
-  committed_(false),
-  contiguous_(true),
   type_(NONE),
-  size_(-1),
+  contiguous_(true),
+  committed_(false),
   pdata_(nullptr),
-  idata_(nullptr),
   vdata_(nullptr),
-  builtin_(false)
+  idata_(nullptr),
+  builtin_(false),
+  size_(-1)
 {
 }
 
@@ -147,7 +147,8 @@ MpiType::init_primitive(const char* labelit, int size)
 void
 MpiType::init_primitive(const std::string& labelit, const int sizeit, int align)
 {
-  init_primitive(labelit.c_str(), sizeit, align);
+  // TODOWARNING init_primitive(labelit.c_str(), sizeit, align);
+  init_primitive(labelit.c_str(), sizeit);
 }
 
 void

--- a/sumi/allgather.h
+++ b/sumi/allgather.h
@@ -63,7 +63,9 @@ class AllgatherCollective : public DagCollective
  protected:
   AllgatherCollective(CollectiveEngine* engine, void* dst, void* src,
                       int nelems, int type_size, int tag, int cq_id, Communicator* comm)
-    : nelems_(nelems), DagCollective(Collective::allgather, engine, dst, src, type_size, tag, cq_id, comm)
+    : 
+    DagCollective(Collective::allgather, engine, dst, src, type_size, tag, cq_id, comm), 
+    nelems_(nelems)
   {
   }
 

--- a/sumi/bcast.cc
+++ b/sumi/bcast.cc
@@ -55,7 +55,7 @@ BinaryTreeBcastActor::bufferAction(void *dst_buffer, void *msg_buffer, Action *a
 }
 
 void
-BinaryTreeBcastActor::init_root(int me, int roundNproc, int nproc)
+BinaryTreeBcastActor::init_root(int  /*me*/, int roundNproc, int nproc)
 {
   int partnerGap = roundNproc / 2;
   while (partnerGap > 0){

--- a/sumi/collective.cc
+++ b/sumi/collective.cc
@@ -96,9 +96,15 @@ Collective::tostr(type_t ty)
 }
 
 Collective::Collective(type_t ty, CollectiveEngine* engine, int tag, int cq_id, Communicator* comm) :
-  type_(ty), engine_(engine), my_api_(engine->tport()), tag_(tag),
-  dom_nproc_(comm->nproc()), dom_me_(comm->myCommRank()),
-  complete_(false), comm_(comm), cq_id_(cq_id),
+  my_api_(engine->tport()), 
+  engine_(engine), 
+  cq_id_(cq_id),
+  comm_(comm), 
+  dom_me_(comm->myCommRank()),
+  dom_nproc_(comm->nproc()), 
+  complete_(false), 
+  tag_(tag),
+  type_(ty), 
   subsequent_(nullptr)
 {
   debug_printf(sumi_collective | sumi_vote,

--- a/sumi/collective.cc
+++ b/sumi/collective.cc
@@ -113,7 +113,7 @@ Collective::Collective(type_t ty, CollectiveEngine* engine, int tag, int cq_id, 
 }
 
 CollectiveDoneMessage*
-Collective::addActors(Collective *coll)
+Collective::addActors(Collective * /*coll*/)
 {
   sprockit::abort("collective:add_actors: collective should not dynamically add actors");
   return nullptr;

--- a/sumi/collective.h
+++ b/sumi/collective.h
@@ -184,7 +184,7 @@ class DoNothingCollective : public Collective
     return "DoNothing collective";
   }
 
-  CollectiveDoneMessage* recv(int target, CollectiveWorkMessage* msg) override { return nullptr; }
+  CollectiveDoneMessage* recv(int  /*target*/, CollectiveWorkMessage*  /*msg*/) override { return nullptr; }
 
   void start() override {}
 

--- a/sumi/collective_actor.cc
+++ b/sumi/collective_actor.cc
@@ -217,7 +217,7 @@ DagCollectiveActor::startAction(Action* ac)
 }
 
 void
-DagCollectiveActor::startShuffle(Action *ac)
+DagCollectiveActor::startShuffle(Action * /*ac*/)
 {
   spkt_throw_printf(sprockit::UnimplementedError,
     "collective %s does not shuffle data - invalid DAG",

--- a/sumi/collective_actor.cc
+++ b/sumi/collective_actor.cc
@@ -100,14 +100,14 @@ debug_print(const char* info, const std::string& rank_str,
 }
 
 CollectiveActor::CollectiveActor(CollectiveEngine* engine, int tag, int cq_id, Communicator* comm) :
-  engine_(engine),
-  tag_(tag),
-  cq_id_(cq_id),
-  comm_(comm),
-  complete_(false),
   my_api_(engine->tport()),
+  engine_(engine),
+  dom_me_(comm->myCommRank()),
   dom_nproc_(comm->nproc()),
-  dom_me_(comm->myCommRank())
+  tag_(tag),
+  comm_(comm),
+  cq_id_(cq_id),
+  complete_(false)
 {
 }
 
@@ -282,7 +282,7 @@ DagCollectiveActor::sendEagerMessage(Action* ac)
 {
   uint64_t num_bytes;
   void* buf = getSendBuffer(ac, num_bytes);
-  auto* msg = my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, num_bytes, buf,
+  /*auto* msg =*/ my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, num_bytes, buf,
                                               cq_id_, cq_id_, Message::collective, engine_->smsgQos(),
                                               type_, dom_me_, ac->partner,
                                               tag_, ac->round, ac->nelems, type_size_,
@@ -316,7 +316,7 @@ DagCollectiveActor::sendRdmaGetHeader(Action* ac)
 {
   uint64_t num_bytes;
   void* buf = getSendBuffer(ac, num_bytes);
-  auto* msg = my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, 64, //use platform-independent size
+  my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, 64, //use platform-independent size
                         buf, Message::no_ack, cq_id_, Message::collective, engine_->rdmaHeaderQos(),
                         type_, dom_me_, ac->partner,
                         tag_, ac->round,

--- a/sumi/collective_actor.h
+++ b/sumi/collective_actor.h
@@ -286,8 +286,8 @@ class Slicer {
 
   virtual void memcpyPackedBufs(void* dst, void* src, int nelems) const = 0;
 
-  virtual void unpackReduce(void* packedBuf, void* unpackedObj,
-            int offset, int nelems) const {
+  virtual void unpackReduce(void*  /*packedBuf*/, void*  /*unpackedObj*/,
+            int  /*offset*/, int  /*nelems*/) const {
     sprockit::abort("slicer for collective does not implement a reduce op");
   }
 

--- a/sumi/collective_actor.h
+++ b/sumi/collective_actor.h
@@ -120,9 +120,10 @@ struct Action
   }
 
   Action(type_t ty, int r, int p) :
-    type(ty), round(r),
+    type(ty), 
     partner(p),
-    join_counter(0)
+    join_counter(0),
+    round(r)
   {
     id = messageId(ty, r, p);
   }
@@ -267,6 +268,8 @@ class Slicer {
  public:
   static reduce_fxn null_reduce_fxn;
 
+  virtual ~Slicer() = default;
+
   /**
    * @brief pack_in
    * @param packedBuf
@@ -391,12 +394,12 @@ class DagCollectiveActor :
                        int type_size, int tag, int cq_id, Communicator* comm,
                        reduce_fxn fxn = Slicer::null_reduce_fxn) :
     CollectiveActor(engine, tag, cq_id, comm),
-    type_(ty),
-    slicer_(new DefaultSlicer(type_size, fxn)),
     type_size_(type_size),
-    result_buffer_(dst),
+    send_buffer_(src),
     recv_buffer_(nullptr),
-    send_buffer_(src)
+    result_buffer_(dst),
+    type_(ty),
+    slicer_(new DefaultSlicer(type_size, fxn))
   {
   }
 

--- a/sumi/collective_message.h
+++ b/sumi/collective_message.h
@@ -61,7 +61,7 @@ class CollectiveDoneMessage :
 {
 
  public:
-  CollectiveDoneMessage(int tag, Collective::type_t ty, Communicator* dom, uint8_t cq_id) :
+  CollectiveDoneMessage(int tag, Collective::type_t ty, Communicator* dom, uint8_t  /*cq_id*/) :
     tag_(tag), result_(0), vote_(0), type_(ty), dom_(dom)
   {
   }

--- a/sumi/communicator.cc
+++ b/sumi/communicator.cc
@@ -200,7 +200,7 @@ MapCommunicator::globalRankSetIntersection(const std::set<int> &neighbors) const
 }
 
 int
-IndexCommunicator::globalToCommRank(int global_rank) const
+IndexCommunicator::globalToCommRank(int  /*global_rank*/) const
 {
   sprockit::abort("index_domain::global_to_comm_rank: this should only be involved in failures");
   return 0;
@@ -232,7 +232,7 @@ SubrangeCommunicator::globalRankSetIntersection(const std::set<int> &neighbors) 
 }
 
 std::set<int>
-RotateCommunicator::globalRankSetIntersection(const std::set<int> &neighbors) const
+RotateCommunicator::globalRankSetIntersection(const std::set<int> & /*neighbors*/) const
 {
   spkt_abort_printf("RotateCommunicator: does not support rank intersection");
   return std::set<int>{};

--- a/sumi/communicator.cc
+++ b/sumi/communicator.cc
@@ -136,7 +136,8 @@ Communicator::createSmpCommunicator(const std::set<int>& neighbors, CollectiveEn
 }
 
 GlobalCommunicator::GlobalCommunicator(Transport *tport) :
-  transport_(tport), Communicator(tport->rank())
+  Communicator(tport->rank()),
+  transport_(tport) 
 {
 }
 
@@ -159,8 +160,8 @@ GlobalCommunicator::globalToCommRank(int global_rank) const
 }
 
 MapCommunicator::MapCommunicator(int rank, std::vector<int>&& local_to_global)
- : local_to_global_(std::move(local_to_global)),
-   Communicator(rank)
+ : Communicator(rank),
+   local_to_global_(std::move(local_to_global))
 {
   for (int idx=0; idx < local_to_global_.size(); ++idx){
     global_to_local_[local_to_global_[idx]] = idx;

--- a/sumi/communicator.h
+++ b/sumi/communicator.h
@@ -178,7 +178,7 @@ class MapCommunicator :
  private:
   std::map<int, int> global_to_local_;
   std::vector<int> local_to_global_;
-  int rank_;
+  // TODOWARNING int rank_;
 };
 
 class ShiftedCommunicator :

--- a/sumi/gatherv.cc
+++ b/sumi/gatherv.cc
@@ -65,17 +65,19 @@ BtreeGathervActor::initTree()
 void
 BtreeGathervActor::initBuffers()
 {
-  void* dst = result_buffer_;
-  void* src = send_buffer_;
-  if (!src)
-    return;
+  // TODOWARNING
+  // void* dst = result_buffer_;
+  // void* src = send_buffer_;
+  // if (!src)
+  //   return;
 }
 
 void
 BtreeGathervActor::finalizeBuffers()
 {
-  if (!result_buffer_)
-    return;
+  // TODOWARNING
+  // if (!result_buffer_)
+  //   return;
 
 }
 
@@ -88,6 +90,7 @@ BtreeGathervActor::bufferAction(void *dst_buffer, void *msg_buffer, Action *ac)
 void
 BtreeGathervActor::initDag()
 {
+#if 0 // TODOWARNING
   int me = comm_->myCommRank();
   int nproc = comm_->nproc();
   int round = 0;
@@ -97,6 +100,7 @@ BtreeGathervActor::initDag()
     //special case to handle the last gather round
     maxGap = midpoint_ / 2;
   }
+#endif
 }
 
 

--- a/sumi/gatherv.h
+++ b/sumi/gatherv.h
@@ -49,6 +49,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sumi/collective_actor.h>
 #include <sumi/collective_message.h>
 #include <sumi/comm_functions.h>
+#include <unusedvariablemacro.h>
 
 namespace sumi {
 
@@ -75,11 +76,11 @@ class BtreeGathervActor :
   void bufferAction(void *dst_buffer, void *msg_buffer, Action* ac) override;
 
  private:
-  int root_;
+  SSTMAC_MAYBE_UNUSED int root_;
   int midpoint_;
   int log2nproc_;
-  int sendcnt_;
-  int* recv_counts_;
+  SSTMAC_MAYBE_UNUSED int sendcnt_;
+  SSTMAC_MAYBE_UNUSED int* recv_counts_;
 
 };
 
@@ -91,7 +92,10 @@ class BtreeGatherv :
   BtreeGatherv(CollectiveEngine* engine, int root, void *dst, void *src,
                 int sendcnt, int *recv_counts, int type_size, int tag, int cq_id, Communicator* comm)
     : DagCollective(gatherv, engine, dst, src, type_size, tag, cq_id, comm),
-      recv_counts_(recv_counts), sendcnt_(sendcnt), root_(root){}
+      sendcnt_(sendcnt), 
+      recv_counts_(recv_counts), 
+      root_(root)
+  {}
 
 
   std::string toString() const override {

--- a/sumi/monitor.h
+++ b/sumi/monitor.h
@@ -82,7 +82,7 @@ class FunctionSet {
 class ActivityMonitor
 {
  public:
-  ActivityMonitor(SST::Params& params,
+  ActivityMonitor(SST::Params&  /*params*/,
                   Transport* t) : api_(t){}
 
   virtual ~ActivityMonitor(){}

--- a/sumi/reduce_scatter.cc
+++ b/sumi/reduce_scatter.cc
@@ -74,7 +74,7 @@ HalvingReduceScatterActor::initDag()
 }
 
 bool
-HalvingReduceScatterActor::isLowerPartner(int virtual_me, int partner_gap)
+HalvingReduceScatterActor::isLowerPartner(int  /*virtual_me*/, int  /*partner_gap*/)
 {
   return false;
 }

--- a/sumi/reduce_scatter.h
+++ b/sumi/reduce_scatter.h
@@ -58,7 +58,7 @@ class HalvingReduceScatterActor :
 
  public:
   HalvingReduceScatterActor(CollectiveEngine* engine, void* dst, void* src,
-                        int nelems, int type_size, int tag,  reduce_fxn fxn, int cq_id, Communicator* comm) :
+                        int  /*nelems*/, int type_size, int tag,  reduce_fxn fxn, int cq_id, Communicator* comm) :
     DagCollectiveActor(Collective::reduce_scatter, engine, dst, src, type_size, tag, cq_id, comm, fxn),
     fxn_(fxn)
   {

--- a/sumi/reduce_scatter.h
+++ b/sumi/reduce_scatter.h
@@ -60,7 +60,7 @@ class HalvingReduceScatterActor :
   HalvingReduceScatterActor(CollectiveEngine* engine, void* dst, void* src,
                         int nelems, int type_size, int tag,  reduce_fxn fxn, int cq_id, Communicator* comm) :
     DagCollectiveActor(Collective::reduce_scatter, engine, dst, src, type_size, tag, cq_id, comm, fxn),
-    fxn_(fxn), nelems_(nelems)
+    fxn_(fxn)
   {
   }
 
@@ -79,11 +79,11 @@ class HalvingReduceScatterActor :
  private:
   reduce_fxn fxn_;
 
-  int nelems_;
+  // TODOWARNING int nelems_;
 
-  int num_reducing_rounds_;
+  // TODOWARNING int num_reducing_rounds_;
 
-  int num_total_rounds_;
+  // TODOWARNING int num_total_rounds_;
 
 };
 

--- a/sumi/scan.cc
+++ b/sumi/scan.cc
@@ -149,7 +149,7 @@ SimultaneousBtreeScanActor::bufferAction(void *dst_buffer, void *msg_buffer, Act
 }
 
 void
-SimultaneousBtreeScanActor::startShuffle(Action *ac)
+SimultaneousBtreeScanActor::startShuffle(Action * /*ac*/)
 {
   int size = type_size_ * nelems_;
   ::memcpy(send_buffer_, result_buffer_, size);

--- a/sumi/scan.h
+++ b/sumi/scan.h
@@ -80,9 +80,9 @@ class SimultaneousBtreeScanActor :
 
   reduce_fxn fxn_;
 
-  int num_reducing_rounds_;
+  // TODOWARNING int num_reducing_rounds_;
 
-  int num_total_rounds_;
+  // TODOWARNING int num_total_rounds_;
 
 };
 

--- a/sumi/scatterv.cc
+++ b/sumi/scatterv.cc
@@ -111,9 +111,9 @@ BtreeScattervActor::bufferAction(void *dst_buffer, void *msg_buffer, Action *ac)
 void
 BtreeScattervActor::initDag()
 {
-  int me = comm_->myCommRank();
-  int nproc = comm_->nproc();
-  int round = 0;
+  // TODOWARNING int me = comm_->myCommRank();
+  // TODOWARNING int nproc = comm_->nproc();
+  // TODOWARNING int round = 0;
 
 }
 

--- a/sumi/scatterv.h
+++ b/sumi/scatterv.h
@@ -62,7 +62,7 @@ class BtreeScattervActor :
   }
 
   BtreeScattervActor(CollectiveEngine* engine, int root, void *dst, void *src,
-                       int* send_counts, int recvcnt, int type_size, int tag,
+                       int*  /*send_counts*/, int recvcnt, int type_size, int tag,
                        int cq_id, Communicator* comm) :
     DagCollectiveActor(Collective::scatter, engine, dst, src, type_size, tag, cq_id, comm),
     root_(root), 

--- a/sumi/scatterv.h
+++ b/sumi/scatterv.h
@@ -65,7 +65,9 @@ class BtreeScattervActor :
                        int* send_counts, int recvcnt, int type_size, int tag,
                        int cq_id, Communicator* comm) :
     DagCollectiveActor(Collective::scatter, engine, dst, src, type_size, tag, cq_id, comm),
-    root_(root), send_counts_(send_counts), recvcnt_(recvcnt) {}
+    root_(root), 
+    recvcnt_(recvcnt) 
+  {}
 
  protected:
   void finalizeBuffers() override;
@@ -79,7 +81,7 @@ class BtreeScattervActor :
   int root_;
   int midpoint_;
   int log2nproc_;
-  int* send_counts_;
+  // TODOWARNING int* send_counts_;
   int recvcnt_;
 
 };

--- a/sumi/sim_transport.cc
+++ b/sumi/sim_transport.cc
@@ -343,7 +343,7 @@ SimTransport::memcopy(uint64_t bytes)
 }
 
 void
-SimTransport::incomingEvent(sstmac::Event *ev)
+SimTransport::incomingEvent(sstmac::Event * /*ev*/)
 {
   spkt_abort_printf("sumi_transport::incoming_event: should not directly handle events");
 }
@@ -1074,7 +1074,7 @@ class PatternQoSAnalysis : public QoSAnalysis
     rdmaCutoff_ = params.find<SST::UnitAlgebra>("rdma_cutoff").getRoundedValue();
   }
 
-  int selectQoS(Message *m) override {
+  int selectQoS(Message * /*m*/) override {
     return 0;
   }
 

--- a/sumi/sim_transport.h
+++ b/sumi/sim_transport.h
@@ -172,7 +172,7 @@ class SimTransport : public Transport, public sstmac::sw::API {
     return buffer;
   }
 
-  void freePublicBuffer(void* buf, uint64_t size) override {
+  void freePublicBuffer(void* buf, uint64_t  /*size*/) override {
     ::free(buf);
   }
 

--- a/tests/Makefile.clang_tests
+++ b/tests/Makefile.clang_tests
@@ -66,7 +66,7 @@ test_clang_%.$(CHKSUF): test_clang_%.tmp-out
 
 test_clang_%_cpp.tmp-out: sst.pp.%.cc $(SSTMAC_DEGLOBAL) 
 	-$(CXX) -std=c++11 -c $< -o tmp.o \
-    -I$(top_srcdir) -I$(top_builddir) \
+    -I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/include \
     -I$(top_srcdir)/sprockit -I$(top_builddir)/sprockit \
     -include sstmac/compute.h -include sstmac/skeleton.h 2>&1 /dev/null | grep error >& $@
 	-cat $< | grep -v '^#' >> $@
@@ -75,7 +75,7 @@ test_clang_%_cpp.tmp-out: sst.pp.%.cc $(SSTMAC_DEGLOBAL)
 
 test_clang_%_c.tmp-out: sst.pp.%.c $(SSTMAC_DEGLOBAL) 
 	-$(CC) -c $< -o tmp.o \
-    -I$(top_srcdir) -I$(top_builddir) \
+    -I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/include \
     -I$(top_srcdir)/sprockit -I$(top_builddir)/sprockit \
     -include sstmac/compute.h -include sstmac/skeleton.h 2>&1 /dev/null | grep error >& $@
 	-cat $< | grep -v '^#' >> $@

--- a/tests/sumi/Makefile.am
+++ b/tests/sumi/Makefile.am
@@ -16,7 +16,7 @@ check_PROGRAMS = \
 #  sst_saturation 
 
 AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) 
-AM_CPPFLAGS += -I$(top_srcdir)/sumi -I$(top_builddir)/sumi
+AM_CPPFLAGS += -I$(top_srcdir)/sumi -I$(top_srcdir)/include -I$(top_builddir)/sumi
 AM_CPPFLAGS += -I$(top_srcdir)/sprockit -I$(top_builddir)/sprockit
 AM_CPPFLAGS += -I$(top_srcdir)/sstmac/install -DSSTMAC=1
 AM_CPPFLAGS += -I$(top_builddir)/sstmac/replacements -I$(top_srcdir)/sstmac/replacements 

--- a/tests/test_blas.cc
+++ b/tests/test_blas.cc
@@ -64,7 +64,7 @@ extern "C" int ubuntu_cant_name_mangle() { return 0; }
 
 #define sstmac_app_name test_blas
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
   run_fxn(sstmac_simple_daxpy,10000);
   run_fxn(sstmac_simple_dgemv,1000,1000);

--- a/tests/test_pthread.cc
+++ b/tests/test_pthread.cc
@@ -56,14 +56,14 @@ using namespace sstmac::hw;
 
 extern "C" int ubuntu_cant_name_mangle() { return 0; }
 
-void* ptest(void* args)
+void* ptest(void*  /*args*/)
 {
    SSTMAC_compute(1); 
    printf("Yes, I reach here!\n");
    return 0;
 }
 
-void* ptest3(void* args)
+void* ptest3(void*  /*args*/)
 {
    SSTMAC_compute(1);
    printf("No, I do not reach here!\n");
@@ -108,7 +108,7 @@ void* ptest2(void* args)
 #define sstmac_app_name test_pthread
 
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
     void* no_args = 0;
     pthread_t thr1, thr2;

--- a/tests/test_std_thread.cc
+++ b/tests/test_std_thread.cc
@@ -79,7 +79,7 @@ void thrash(std::mutex* mtx)
 #define sstmac_app_name test_std_thread
 
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
   std::string str1("I got my head checked");
   std::thread t1(fxn1, str1);

--- a/tests/test_tls.cc
+++ b/tests/test_tls.cc
@@ -56,7 +56,7 @@ struct tag1{}; struct tag2{};
 sstmac::CppVarTemplate<tag1,int,true> count(0);
 sstmac::CppVarTemplate<tag2,int,true> id(0);
 
-void thrash(std::mutex* mtx, int myId)
+void thrash(std::mutex*  /*mtx*/, int myId)
 {
   id() = myId;
   for (int i=0; i < 3; ++i){
@@ -70,7 +70,7 @@ void thrash(std::mutex* mtx, int myId)
 
 #define sstmac_app_name test_tls
 
-int USER_MAIN(int argc, char** argv)
+int USER_MAIN(int  /*argc*/, char**  /*argv*/)
 {
   //now test some mutexes
   std::mutex mtx;


### PR DESCRIPTION
Manually fixed all warnings from -Wall with clang-8 and then used clang-tidy to fix warnings from unused params automatically.  I need Jenkins to test the configurations I don't have access to. 