### PR TITLE
Added a string replace_all method.

### DIFF
--- a/bin/clang/util.cc
+++ b/bin/clang/util.cc
@@ -367,5 +367,16 @@ std::string replace_all(std::string const &str, std::string const& match,
   return result_string;
 }
 
+std::string replace_all(std::string const &str,
+    std::map<std::string, std::string> const& replacements) {
+
+  std::string result = str;
+  for(auto const& pair : replacements){
+    result = replace_all(result, pair.first, pair.second);
+  }
+
+  return result;
+}
+
 } // namespace strings
 } // namespace sst

--- a/bin/clang/util.cc
+++ b/bin/clang/util.cc
@@ -44,6 +44,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include "util.h"
 #include <sstream>
+#include <cstring>
 
 using namespace clang;
 using namespace clang::driver;
@@ -336,3 +337,35 @@ std::string getLiteralDataAsString(const Token &tok)
   return sstr.str();
 }
 
+
+namespace sst {
+namespace strings {
+
+std::string replace_all(std::string const &str, std::string const& match, 
+                      std::string const& replacement) {
+  const auto match_len = match.size();
+  const auto replacement_len = replacement.size();
+
+  // Copy the input
+  std::string result_string = str;
+
+  // Need to keep track of where to pick the search back up so that we don't
+  // end up in an infinite loop if the replacement string contains the match as
+  // a substring.
+  auto search_start_pos = 0;
+
+  for(;;){
+    auto match_start_position = result_string.find(match, search_start_pos);
+    if (match_start_position != std::string::npos) {
+      result_string.replace(match_start_position, match_len, replacement);
+      search_start_pos = match_start_position + replacement_len;
+    } else {
+      break;
+    }
+  }
+
+  return result_string;
+}
+
+} // namespace strings
+} // namespace sst

--- a/bin/clang/util.h
+++ b/bin/clang/util.h
@@ -48,6 +48,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #include "clangHeaders.h"
 #include <clangtidymacros.h>
 
+#include <string>
 #include <iostream>
 #include "clangGlobals.h"
 
@@ -175,5 +176,13 @@ clang::Expr* zeroExpr(clang::SourceLocation loc);
 clang::Expr* tokenToExpr(clang::DeclContext* ctx,
                          const clang::Token& tok, clang::SourceLocation loc);
 
+namespace sst {
+namespace strings {
+/// Function that returns a string that is a copy of str with match replaced
+/// by replacement
+std::string replace_all(std::string const &str, std::string const& match,
+                        std::string const& replacement);
+} // namespace strings
+} // namespace sst
 
 #endif

--- a/bin/clang/util.h
+++ b/bin/clang/util.h
@@ -182,6 +182,11 @@ namespace strings {
 /// by replacement
 std::string replace_all(std::string const &str, std::string const& match,
                         std::string const& replacement);
+
+/// Function that runs replace_all on every pair in the map of replacements
+std::string replace_all(std::string const &str,
+    std::map<std::string, std::string> const& replacements);
+
 } // namespace strings
 } // namespace sst
 


### PR DESCRIPTION
Add a function to make it easier to replace substrings in strings for example 

```cpp
void func() {
  std::string str =
R"lit(
int func($params){
  func2($names);
  collect($names);
  return;
}
)lit";

  str = replace_all(str, "$params", "int a, int b, double c, double d");
  str = replace_all(str, "$names", "a, b, c, d");
  std::cout << str;

  std::cout << "Replace a with aa\n";
  str = replace_all(str, "a", "aa");
  std::cout << str;
}
```
should output 
```
int func(int a, int b, double c, double d){
  func2(a, b, c, d);
  collect(a, b, c, d);
  return;
}
Replace a with aa

int func(int aa, int b, double c, double d){
  func2(aa, b, c, d);
  collect(aa, b, c, d);
  return;
}
```
