### PR TITLE
add -Werror flags for certain builds: Issue #522

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/sprockit -I$(top_builddir)/sprockit
 AM_LDFLAGS = 
-AM_CXXFLAGS = $(STD_CXXFLAGS)
-AM_CFLAGS =
+AM_CXXFLAGS = $(STD_CXXFLAGS) $(ERROR_CXXFLAGS)
+AM_CFLAGS = $(ERROR_CFLAGS)
 
 if INTEGRATED_SST_CORE
   AM_CPPFLAGS += $(SST_CPPFLAGS)

--- a/acinclude/check_werror.m4
+++ b/acinclude/check_werror.m4
@@ -1,0 +1,34 @@
+
+
+AH_TEMPLATE([ERROR_CFLAGS], [Contains -Werror flags])
+AH_TEMPLATE([ERROR_CXXFLAGS], [Contains -Werror flags])
+AC_DEFUN([CHECK_WERROR], [
+
+  AC_MSG_CHECKING([whether to use -Werror build])
+  AC_ARG_WITH(werror,
+    [
+      AS_HELP_STRING(
+        [--with-werror],
+        [Whether to build with Werror]
+      )
+    ],
+    [
+      add_werror=$withval
+    ], 
+    [
+      add_werror=no
+    ]
+  )
+  AC_MSG_RESULT([$add_werror])
+
+  if test "$add_werror" != "no"; then
+    ERROR_CFLAGS="-Werror"
+    ERROR_CXXFLAGS="-Werror"
+  else
+    ERROR_CFLAGS=""
+    ERROR_CXXFLAGS=""
+  fi
+
+  AC_SUBST(ERROR_CFLAGS)
+  AC_SUBST(ERROR_CXXFLAGS)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,8 @@ CHECK_COMM_DELAY_STATS()
 
 CHECK_CLANG_LLVM()
 
+CHECK_WERROR()
+
 
 #-------------------------------------------------
 # Configure subdirs


### PR DESCRIPTION
Adds Werror flags after configure, avoids issue where autools cannot configure with -Werror in CXXFLAGS