### PR TITLE
fix anon parameters for C

### DIFF
--- a/sstmac/libraries/pthread/sstmac_sched.cc
+++ b/sstmac/libraries/pthread/sstmac_sched.cc
@@ -190,3 +190,15 @@ SSTMAC_sched_getaffinity (pid_t  /*pid*/, size_t  /*cpusetsize*/, sstmac_cpu_set
   cpuset->cpubits = t->cpumask();
   return 0;
 }
+
+/* Get maximum priority value for a scheduler.  */
+extern "C"
+int SSTMAC_sched_get_priority_max(int /*algorithm*/){
+  return 99;
+}
+
+/* Get minimum priority value for a scheduler.  */
+extern "C"
+int SSTMAC_sched_get_priority_min(int  /*algorithm*/){
+  return 1;
+}

--- a/sstmac/libraries/pthread/sstmac_sched.h
+++ b/sstmac/libraries/pthread/sstmac_sched.h
@@ -73,14 +73,10 @@ extern int SSTMAC_sched_getscheduler (pid_t pid);
 extern int SSTMAC_sched_yield (void);
 
 /* Get maximum priority value for a scheduler.  */
-static inline int SSTMAC_sched_get_priority_max (int  /*algorithm*/){
-  return 99;
-}
+extern int SSTMAC_sched_get_priority_max(int algorithm);
 
 /* Get minimum priority value for a scheduler.  */
-static inline int SSTMAC_sched_get_priority_min (int  /*algorithm*/){
-  return 1;
-}
+extern int SSTMAC_sched_get_priority_min(int algorithm);
 
 /* Get the SCHED_RR interval for the named process.  */
 struct timespec;


### PR DESCRIPTION
Anonymous parameters were used to fix C++ warnings. However, some of these functions get included from C code. This refactors to avoid making these functions visible to C.