### PR TITLE
fix use of Spack compiler wrappers

### DIFF
--- a/bin/sstcclib.py
+++ b/bin/sstcclib.py
@@ -241,18 +241,10 @@ def run(typ, extraLibs=""):
   from sstccvars import clangCppFlagsStr, clangLdFlagsStr
   from sstccutils import cleanFlag, getProcTree, swapSuffix
 
-  ctx = Context()
-  ctx.sstCore = sstCore
-  ctx.cc = spackcc if spackcc else cc
-  ctx.cxx = spackcxx if spackcxx else cxx
-  ctx.typ = typ
 
   needfPIC = "fPIC" in sstCxxFlagsStr
 
   sstmacExe = cleanFlag(os.path.join(prefix, "bin", "sstmac"))
-
-  ctx.sstCore = sstCore
-  ctx.hasClang = bool(clangCppFlagsStr)
 
   verbose = False     #whether to print verbose output
   delTempFiles = True #whether to delete all temp files created
@@ -287,11 +279,6 @@ def run(typ, extraLibs=""):
         makeBashExe = True
 
 
-  for entry in sstCppFlags:
-    clean = cleanFlag(entry)
-    if clean: #don't add empty flags
-      ctx.cppFlags.append(clean)
-
   import argparse
   parser = argparse.ArgumentParser(description='Process flags for the SST/macro compiler wrapper')
   parser.add_argument('-o', '--output', type=str,  
@@ -325,16 +312,31 @@ def run(typ, extraLibs=""):
   
   args, extraArgs = parser.parse_known_args()
 
+  ctx = Context()
+
+  for entry in sstCppFlags:
+    clean = cleanFlag(entry)
+    if clean: #don't add empty flags
+      ctx.cppFlags.append(clean)
+
+  ctx.sstCore = sstCore
+  ctx.cc = spackcc if spackcc else cc
+  ctx.cxx = spackcxx if spackcxx else cxx
+  ctx.typ = typ
+  ctx.sstCore = sstCore
+  ctx.hasClang = bool(clangCppFlagsStr)
+
+
   #it is possible to override the host compilers use to do preprocessing/compilation
   if args.host_cxx:
-    cxx = args.host_cxx
+    ctx.cxx = args.host_cxx
   elif "SSTMAC_CXX" in os.environ:
-    cxx = os.environ["SSTMAC_CXX"]
+    ctx.cxx = os.environ["SSTMAC_CXX"]
 
   if args.host_cc:
-    cc = args.host_cc
+    ctx.cc = args.host_cc
   elif "SSTMAC_CC" in os.environ:
-    cc = os.environ["SSTMAC_CC"]
+    ctx.cc = os.environ["SSTMAC_CC"]
 
   if args.no_integrated_cpp:
     sys.exit("SST compiler wrapper cannot handle --no-integrated-cpp flag")
@@ -448,8 +450,8 @@ def run(typ, extraLibs=""):
   compiler = ""
   sstCompilerFlags = []
   if typ.lower() == "c++":
-    ctx.compiler = cxx
-    ctx.ld = cxx
+    ctx.compiler = ctx.cxx
+    ctx.ld = ctx.cxx
     ctx.compilerFlags = ctx.cxxFlags
     if args.std:
 #        let's turn off this warning for now
@@ -462,12 +464,12 @@ def run(typ, extraLibs=""):
       pass
     ctx.compilerFlags = ctx.cxxFlags[:]
   elif typ.lower() == "c":
-    ctx.compiler = cc
+    ctx.compiler = ctx.cc
     if ctx.hasClang:
       #always use c++ for linking since we are bringing a bunch of sstmac C++ into the game
-      ctx.ld = cxx
+      ctx.ld = ctx.cxx
     else:
-      ctx.ld = cc 
+      ctx.ld = ctx.cc
     if args.std:
       ctx.cFlags.append("-std=%s" % args.std)
     elif sstCArgs.std:
@@ -480,7 +482,7 @@ def run(typ, extraLibs=""):
     import inspect, os
     pathStr = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
     print(pathStr)
-    cmd = "%s --version" % (cxx)
+    cmd = "%s --version" % (ctx.cxx)
     os.system(cmd)
     sys.exit()
   elif args.flags:
@@ -500,7 +502,7 @@ def run(typ, extraLibs=""):
   if asmFiles:
     #just execute the command as-is with no frills
     cmdArr = [
-      cc
+      ctx.cc
     ]
     cmdArr.extend(sys.argv[1:])
     cmds = [ [None,cmdArr,[]] ]


### PR DESCRIPTION
Use the underlying compiler in sst++, not the Spack compiler wrapper, when building skeletons.