### PR TITLE
fix pragma deletion logic: Issue #577

### DIFF
--- a/bin/clang/astVisitor.cc
+++ b/bin/clang/astVisitor.cc
@@ -2461,10 +2461,8 @@ void
 PragmaActivateGuard::deletePragmaText(SSTPragma *prg)
 {
   //eliminate the pragma text
-  if (prg->depth == 0){
-    SourceRange rng(prg->pragmaDirectiveLoc, prg->endPragmaLoc);
-    ::replace(rng, "");
-  }
+  SourceRange rng(prg->pragmaDirectiveLoc, prg->endPragmaLoc);
+  ::replace(rng, "");
 }
 
 void

--- a/bin/clang/pragmas.cc
+++ b/bin/clang/pragmas.cc
@@ -265,7 +265,6 @@ SSTPragmaHandler::configure(bool delOnUse, Token&  /*PragmaTok*/, Preprocessor& 
     maxPragmaDepth = 0;
   }
   --pragmaDepth;
-  fsp->depth = pragmaDepth;
 }
 
 void

--- a/bin/clang/pragmas.h
+++ b/bin/clang/pragmas.h
@@ -75,7 +75,6 @@ struct SSTPragma {
   clang::SourceLocation startPragmaLoc;
   clang::SourceLocation endPragmaLoc;
   clang::SourceLocation targetLoc;
-  int depth;
   bool deleteOnUse;
   std::uintptr_t classId;
 

--- a/tests/Makefile.clang_tests
+++ b/tests/Makefile.clang_tests
@@ -30,6 +30,7 @@ CLANGTESTS = \
   pragma_sst_scoped_replace_cpp \
   pragma_sst_replace_cpp \
   pragma_sst_memory_cpp \
+  pragma_sst_multi_pragma_cpp \
   pragma_sst_compute_cpp \
   pragma_sst_compute_global_var_cpp \
   pragma_sst_loop_count_cpp \

--- a/tests/clang_src2src/pragma_sst_multi_pragma.cc
+++ b/tests/clang_src2src/pragma_sst_multi_pragma.cc
@@ -1,0 +1,68 @@
+/**
+Copyright 2009-2020 National Technology and Engineering Solutions of Sandia,
+LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S.  Government 
+retains certain rights in this software.
+
+Sandia National Laboratories is a multimission laboratory managed and operated
+by National Technology and Engineering Solutions of Sandia, LLC., a wholly 
+owned subsidiary of Honeywell International, Inc., for the U.S. Department of 
+Energy's National Nuclear Security Administration under contract DE-NA0003525.
+
+Copyright (c) 2009-2020, NTESS
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Questions? Contact sst-macro-help@sandia.gov
+*/
+
+int fxn()
+{
+  int i=0;
+  int mul = 0;
+  double* x = new double[10];
+  int* idx = new int[5];
+#pragma sst memory 10
+#pragma sst compute
+  for (i=0; i < 5; ++i){
+    mul *= i;
+    for (int j=0; j < 10; ++j){
+      mul += (j-1);
+      x[j] += i;
+      mul -= x[j];
+      j=7;
+      mul += x[j];
+      mul *= x[idx[i]];
+      idx[i] -= 3;
+      mul *= x[idx[i]];
+    }
+  }
+  return 0;
+}
+

--- a/tests/reference/test_clang_pragma_sst_memory_cpp.ref-out
+++ b/tests/reference/test_clang_pragma_sst_memory_cpp.ref-out
@@ -5,6 +5,7 @@ int fxn()
   double* x = new double[10];
   int* idx = new int[5];
 
+
  { uint64_t flops=0; uint64_t readBytes=0; uint64_t writeBytes=0; uint64_t intops=0; {  uint64_t tripCount0=(((5)-(0)));  intops += tripCount0*1;{  uint64_t tripCount1=tripCount0*(((10)-(0)));  flops += tripCount1*1; readBytes += tripCount1*36; writeBytes += tripCount1*12; intops += tripCount1*16;}}readBytes=1000;sstmac_compute_detailed(flops,intops,readBytes); }
 
 

--- a/tests/reference/test_clang_pragma_sst_multi_pragma_cpp.ref-out
+++ b/tests/reference/test_clang_pragma_sst_multi_pragma_cpp.ref-out
@@ -1,0 +1,26 @@
+int fxn()
+{
+  int i=0;
+  int mul = 0;
+  double* x = new double[10];
+  int* idx = new int[5];
+
+
+ { uint64_t flops=0; uint64_t readBytes=0; uint64_t writeBytes=0; uint64_t intops=0; {  uint64_t tripCount0=(((5)-(0)));  intops += tripCount0*1;{  uint64_t tripCount1=tripCount0*(((10)-(0)));  flops += tripCount1*1; readBytes += tripCount1*36; writeBytes += tripCount1*12; intops += tripCount1*16;}}readBytes=10;sstmac_compute_detailed(flops,intops,readBytes); }
+
+
+
+
+
+
+
+
+
+
+
+
+  return 0;
+}
+#include <sstmac/software/process/cppglobal.h>
+#include <sstmac/software/process/memoize.h>
+

--- a/tests/reference/test_clang_pragma_sst_replace_cpp.ref-out
+++ b/tests/reference/test_clang_pragma_sst_replace_cpp.ref-out
@@ -28,6 +28,7 @@ void fxn3()
  int x = 42;
 
 
+
  for (int i=0; i < 3; ++i){
     int x = 10;
     int z = 42;


### PR DESCRIPTION
Not sure why the original logic was there. There's no reason to track pragma depth anymore.