### PR TITLE
Fix function skip bug for pragmas on FunctionDecls

### DIFF
--- a/bin/clang/astConsumers.cc
+++ b/bin/clang/astConsumers.cc
@@ -65,24 +65,13 @@ SkeletonASTConsumer::HandleTopLevelDecl(DeclGroupRef DR)
 {
   for (DeclGroupRef::iterator b = DR.begin(), e = DR.end(); b != e; ++b){
     Decl* d = *b;
-    switch(d->getKind()){
-     case Decl::Function: {
-        FunctionDecl* fd = cast<FunctionDecl>(d);
-        //the function decl will have its body filled in later
-        //possibly - we need to make sure to only add the function once
-        if (fd->isThisDeclarationADefinition()){
-          //also, we only really care about the definition anyway
-          allTopLevelDecls_.push_back(d);
-        }
-        if (isNullWhitelisted(fd->getNameAsString())){
-          CompilerGlobals::astNodeMetadata.nullSafeFunctions[fd] = nullptr;
-        }
+    if (d->getKind() == Decl::Function){
+      FunctionDecl* fd = cast<FunctionDecl>(d);
+      if (isNullWhitelisted(fd->getNameAsString())){
+        CompilerGlobals::astNodeMetadata.nullSafeFunctions[fd] = nullptr;
       }
-      break;
-     default:
-      allTopLevelDecls_.push_back(d);
-      break;
     }
+    allTopLevelDecls_.push_back(d);
   }
   return true;
 }

--- a/bin/clang/pragmas.cc
+++ b/bin/clang/pragmas.cc
@@ -152,6 +152,9 @@ static void tokenToString(const Token& tok, std::ostream& os)
   case tok::kw_true:
     os << "true";
     break;
+  case tok::kw_void:
+    os << "void";
+    break;
   case tok::kw_false:
     os << "false";
     break;

--- a/sstmac/replacements/string.h
+++ b/sstmac/replacements/string.h
@@ -75,14 +75,10 @@ extern "C" {
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #endif
 
-#if defined(__clang__) // Only include S2S things if clang
 #pragma sst null_ptr safe
-#endif
 void* sstmac_memset(void* ptr, int value, unsigned long  sz);
 
-#if defined(__clang__) // Only include S2S things if clang
 #pragma sst null_ptr safe
-#endif
 void* sstmac_memcpy(void* dst, const void* src, unsigned long sz);
 
 #if defined(__clang__) // Add back the warnings


### PR DESCRIPTION
codes using nullptr pragmas were not building correctly due to the pragmas not being activated.  Even though we do not traverse FunctionDecl's without a body, we still need to process pragmas on them.