### PR TITLE
First pass for testing SST-Macro

### DIFF
--- a/sstmac/install/Makefile.am
+++ b/sstmac/install/Makefile.am
@@ -76,5 +76,9 @@ SST_REGISTER_TOOL=@sst_prefix@/bin/sst-register
 register:
 	  $(SST_REGISTER_TOOL) SST_MACRO SST_MACRO_LIBDIR=@libdir@
 
+install-exec-hook:
+	  $(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE sst-macro=$(abs_srcdir)/../..
+	  $(SST_REGISTER_TOOL) SST_ELEMENT_TESTS sst-macro=$(abs_srcdir)/../../tests
+
 endif
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -58,7 +58,8 @@ EXTRA_DIST = \
   runtest \
   checktest \
   checkdiff \
-  noop
+  noop \
+  testsuite_default_sst_macro.py
 
 
 CORE_LIBS = ../sstmac/install/libsstmac.la ../sprockit/sprockit/libsprockit.la
@@ -97,7 +98,7 @@ CHECK_TESTS = \
   $(COVERAGETESTS) \
   $(ALLOCTESTS) \
   $(SINGLETESTS) \
-  $(UNITTESTS) 
+  $(UNITTESTS)
 
 if USE_REPLACEMENT_HEADERS
 CHECK_TESTS += $(EXTERNALTESTS)
@@ -108,13 +109,13 @@ INSTALLCHECK_TESTS = \
   $(TUTORIALTESTS)
 
 if INTEGRATED_SST_CORE
-INSTALLCHECK_TESTS += $(APITESTS) 
+INSTALLCHECK_TESTS += $(APITESTS)
 else
 CHECK_TESTS += $(APITESTS)
 endif
 
 
-print-tests: 
+print-tests:
 	echo $(CHECK_TESTS)
 
 check-local: $(CHECK_TESTS:%=%.$(CHKSUF))
@@ -129,7 +130,7 @@ installcheck-local: $(INSTALLCHECK_TESTS:%=%.$(CHKSUF))
 #  Clean                                                                                {{{#
 #------------------------------------------------------------------------------------------#
 
-clean-local: clean-skeletons 
+clean-local: clean-skeletons
 	rm -f *.$(CHKSUF)
 	rm -f *.tmp-out
 	rm -f net.dot

--- a/tests/testsuite_default_sst_macro.py
+++ b/tests/testsuite_default_sst_macro.py
@@ -48,7 +48,7 @@ class testcase_sst_macro(SSTTestCase):
 
 #####
 
-    def sst_macro_test_template(self, testcase, testtimeout = 60):
+    def sst_macro_test_template(self, testcase, testtimeout = 120):
         # Get the path to the test files
         test_path = self.get_testsuite_dir()
         outdir = self.get_test_output_run_dir()

--- a/tests/testsuite_default_sst_macro.py
+++ b/tests/testsuite_default_sst_macro.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+from sst_unittest import *
+from sst_unittest_support import *
+
+################################################################################
+# Code to support a single instance module initialize, must be called setUp method
+
+module_init = 0
+module_sema = threading.Semaphore()
+
+def initializeTestModule_SingleInstance(class_inst):
+    global module_init
+    global module_sema
+
+    module_sema.acquire()
+    if module_init != 1:
+        # Put your single instance Init Code Here
+        module_init = 1
+    module_sema.release()
+
+################################################################################
+
+class testcase_sst_macro(SSTTestCase):
+
+    def initializeClass(self, testName):
+        super(type(self), self).initializeClass(testName)
+        # Put test based setup code here. it is called before testing starts
+        # NOTE: This method is called once for every test
+
+    def setUp(self):
+        super(type(self), self).setUp()
+        initializeTestModule_SingleInstance(self)
+        # Put test based setup code here. it is called once before every test
+
+    def tearDown(self):
+        # Put test based teardown code here. it is called once after every test
+        super(type(self), self).tearDown()
+
+#####
+
+    def test_sst_macro_make_check(self):
+        self.sst_macro_test_template("check")
+
+    def test_sst_macro_make_installcheck(self):
+        self.sst_macro_test_template("installcheck")
+
+
+#####
+
+    def sst_macro_test_template(self, testcase, testtimeout = 60):
+        # Get the path to the test files
+        test_path = self.get_testsuite_dir()
+        outdir = self.get_test_output_run_dir()
+        tmpdir = self.get_test_output_tmp_dir()
+
+        MacroElementDir = os.path.abspath("{0}/../".format(test_path))
+
+        # Set the various file paths
+        testDataFileName="test_sst_macro_{0}".format(testcase)
+        outfile = "{0}/{1}.out".format(outdir, testDataFileName)
+        errfile = "{0}/{1}.err".format(outdir, testDataFileName)
+
+        # Launch SST-Macro Test
+        oscmd = "make {0}".format(testcase)
+        rtn = OSCommand(oscmd, output_file_path = outfile,
+                        error_file_path = errfile,
+                        set_cwd = MacroElementDir).run(timeout_sec=testtimeout)
+
+        # Look for runtime error conditions
+        err_str = "SST-Macro Timed-Out ({0} secs) while running {1}".format(testtimeout, oscmd)
+        self.assertFalse(rtn.timeout(), err_str)
+        err_str = "SST-Macro returned {0}; while running {1}".format(rtn.result(), oscmd)
+        self.assertEqual(rtn.result(), 0, err_str)
+


### PR DESCRIPTION
This is the initial cut at a testsuite for the new testing frameworks.  The frameworks does require sst-core to be installed and the Macro tests directory must be registered with the core (as an element).  

To run the test frameworks, build and install sst-core normally.  Then build and install (this branch of) macro normally.  As long as sst is in the path, you can run sst-test-elements and the frameworks should perform the tests.

You can also test the core by running sst-test-core.