### PR TITLE
noop python exe needs to be determined by configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,7 @@ AC_CONFIG_FILES([bin/sst++], [chmod +x bin/sst++])
 AC_CONFIG_FILES([bin/sstcc], [chmod +x bin/sstcc])
 AC_CONFIG_FILES([bin/sstccvars.py])
 AC_CONFIG_FILES([tests/runtest], [chmod +x tests/runtest])
+AC_CONFIG_FILES([tests/noop], [chmod +x tests/noop])
 AC_CONFIG_FILES([tests/checktest], [chmod +x tests/checktest])
 AC_CONFIG_FILES([tests/checkdiff], [chmod +x tests/checkdiff])
 

--- a/tests/noop.in
+++ b/tests/noop.in
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! @pyexe@
 
 import sys
 import os


### PR DESCRIPTION
@allevin reports that sst-macro testing fails on Ubuntu 20.04.

I believe that this happens because the tests/noop script uses "python" rather than the configure-determined "@pyexe@". This pull request changes tests/noop to a configure-generated script and makes use of the configure-determined python exe.
