### PR TITLE
Changes that will allow us to trigger nightly builds on gitlab ci.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,58 @@
+default:
+  image: ${container_registry}/sst-base-env-ubuntu20.04:0.2
+  tags:
+    - xlarge
+
+stages:
+  - build-nodep
+  - build-with-core
+
+build:core:
+  stage: build-nodep
+  script:
+    - git clone --single-branch --branch devel https://github.com/sstsimulator/sst-core.git sst-core
+    - cmake -B core-build sst-core/experimental -DCMAKE_INSTALL_PREFIX=core-install
+    - cmake --build core-build -j $(nproc)
+    - cmake --install core-build
+    - core-install/bin/sst-test-core
+  artifacts:
+    name: core-install
+    expire_in: 1 week
+    paths:
+      - core-install/
+
+build:no-core:
+  stage: build-nodep
+  script:
+    - sh bootstrap.sh
+    - mkdir -p build
+    - cd build && ../configure
+    - make -j $(nproc)
+    - make check
+
+build:mpi-no-core:
+  extends: bild:no-core
+  variables:
+    CC: mpicc
+    CXX: mpic++
+    MPI_LAUNCHER: 'mpirun -np 3 --allow-run-as-root'
+  allow_failure: true
+
+build:with-core:
+  stage: build-with-core
+  needs:
+    job: build:core
+    artifacts: true
+  script:
+    - sh bootstrap.sh
+    - mkdir -p build
+    - cd build && ../configure --with-sst-core=$PWD/../core-install
+    - make -j $(nproc)
+    - make check
+
+build:mpi-core:
+  extends: build:with-core
+  variables:
+    CC: mpicc
+    CXX: mpic++
+    MPI_LAUNCHER: 'mpirun -np 3 --allow-run-as-root'

--- a/bin/config_tools/check_repo_build
+++ b/bin/config_tools/check_repo_build
@@ -48,10 +48,11 @@ import sys
 from configlib import getoutput 
 
 if os.path.isdir(".git"):
+  branch = getoutput("git rev-parse --abbrev-ref HEAD").strip()
   if branch == "HEAD": # detached head state
     sys.stdout.write("\n")
   else:
-    print(getoutput("git rev-parse --abbrev-ref HEAD").strip())
+    print(branch)
 else:
   sys.stdout.write("\n")
 

--- a/bin/config_tools/check_repo_build
+++ b/bin/config_tools/check_repo_build
@@ -48,7 +48,10 @@ import sys
 from configlib import getoutput 
 
 if os.path.isdir(".git"):
-  print(getoutput("git rev-parse --abbrev-ref HEAD").strip())
+  if branch == "HEAD": # detached head state
+    sys.stdout.write("\n")
+  else:
+    print(getoutput("git rev-parse --abbrev-ref HEAD").strip())
 else:
   sys.stdout.write("\n")
 


### PR DESCRIPTION
These changes will put a CI/CD file in the main repo that allows our gitlab mirror to run scheduled tests against the code. 

The changes to the `check_repo_build` make sure that we don't have a build error when the source is in a detached head state.  This was broken before, but just a low frequency occurrence.  But the Gitlab CI runs in a detached head state so we need to make sure we can build in that case. 