### PR TITLE
Arg typo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ build:no-core:
     - make check
 
 build:mpi-no-core:
-  extends: bild:no-core
+  extends: build:no-core
   variables:
     CC: mpicc
     CXX: mpic++


### PR DESCRIPTION
There was a typo that the current testing had no way of discovering. 