### PR TITLE
Disable standalone parallel DES and fix NetworkMessage serialization

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,7 @@ build:no-core:
     - mkdir -p build
     - cd build && ../configure
     - make -j $(nproc)
+    - make install
     - make check
     - make installcheck
 
@@ -41,6 +42,7 @@ build:with-core:
     - mkdir -p build
     - cd build && ../configure --with-sst-core=$PWD/../core-install
     - make -j $(nproc)
+    - make install
     - make check
     - make installcheck
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,14 +29,7 @@ build:no-core:
     - cd build && ../configure
     - make -j $(nproc)
     - make check
-
-build:mpi-no-core:
-  extends: build:no-core
-  variables:
-    CC: mpicc
-    CXX: mpic++
-    MPI_LAUNCHER: 'mpirun -np 3 --allow-run-as-root'
-  allow_failure: true
+    - make installcheck
 
 build:with-core:
   stage: build-with-core
@@ -49,6 +42,7 @@ build:with-core:
     - cd build && ../configure --with-sst-core=$PWD/../core-install
     - make -j $(nproc)
     - make check
+    - make installcheck
 
 build:mpi-core:
   extends: build:with-core

--- a/acinclude/check_mpi.m4
+++ b/acinclude/check_mpi.m4
@@ -1,15 +1,20 @@
-
+AC_DEFUN([DISABLE_MPI_PARALLEL], [
+AC_DEFINE_UNQUOTED([HAVE_VALID_MPI], 0, "working MPI not found")
+AC_DEFINE_UNQUOTED([DEFAULT_ENV_STRING], "serial", "Default to mpi environment")
+AC_DEFINE_UNQUOTED([DEFAULT_RUNTIME_STRING], "serial", "Default to mpi runtime")
+AC_DEFINE_UNQUOTED([DEFAULT_PARTITION_STRING], "serial", "Default to basic block partition")
+AC_DEFINE_UNQUOTED([DEFAULT_EVENT_MANAGER_STRING], "map", "Default clock cycle parallelism")
+AM_CONDITIONAL([USE_MPIPARALLEL], false)
+with_mpiparallel=false
+])
 
 AC_DEFUN([CHECK_MPI_PARALLEL], [
 
-
 if test "X$have_mpi_header" = "Xyes"; then
   AC_CHECK_FUNCS([MPI_Init],
-    AC_MSG_RESULT([yes])
     found_mpi=yes,
     found_mpi=no)
 fi
-
 
 AC_MSG_CHECKING([MPI])
 if test "X$found_mpi" = "Xyes"; then
@@ -23,14 +28,8 @@ if test "X$found_mpi" = "Xyes"; then
   AM_CONDITIONAL([USE_MPIPARALLEL], true)
   with_mpiparallel=true
 else
-  AC_DEFINE_UNQUOTED([HAVE_VALID_MPI], 0, "working MPI not found")
   AC_MSG_RESULT([no])
-  AC_DEFINE_UNQUOTED([DEFAULT_ENV_STRING], "serial", "Default to mpi environment")
-  AC_DEFINE_UNQUOTED([DEFAULT_RUNTIME_STRING], "serial", "Default to mpi runtime")
-  AC_DEFINE_UNQUOTED([DEFAULT_PARTITION_STRING], "serial", "Default to basic block partition")
-  AC_DEFINE_UNQUOTED([DEFAULT_EVENT_MANAGER_STRING], "map", "Default clock cycle parallelism")
-  AM_CONDITIONAL([USE_MPIPARALLEL], false)
-  with_mpiparallel=false
+  DISABLE_MPI_PARALLEL()
 fi
 
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -150,7 +150,19 @@ AC_CHECK_HEADERS([mpi.h],
 
 CHECK_CXX_STD()
 
-CHECK_MPI_PARALLEL()
+if test "X$have_integrated_core" = "Xyes"; then
+  CHECK_MPI_PARALLEL()
+else
+  DISABLE_MPI_PARALLEL()
+  if test "X$have_mpi_header" = "Xyes"; then
+    AC_CHECK_FUNCS([MPI_Init],
+      found_mpi=yes,
+      found_mpi=no)
+  fi
+  if test "X$found_mpi" = "Xyes"; then
+    AC_MSG_ERROR([MPI compiler detected without sst-core, MPI parallel is only supported with sst-core])
+  fi
+fi
 
 CHECK_SPACK()
 

--- a/sstmac/hardware/network/network_message.cc
+++ b/sstmac/hardware/network/network_message.cc
@@ -286,23 +286,20 @@ NetworkMessage::serialize_order(serializer& ser)
 {
   Flow::serialize_order(ser);
 
-  // can't serialize a nullptr!
-  // (and for UNPACK wire_buffer_ won't have been initialized yet)
-  if (ser.mode() == SST::Core::Serialization::serializer::SIZER ||
-      ser.mode() == SST::Core::Serialization::serializer::PACK ) {
-      if (wire_buffer_ == nullptr) {
-          wire_is_null_ = true;
-        }
-    }
-  ser & wire_is_null_;
+  // Can't serialize a nullptr!
+  bool wire_is_null = wire_buffer_ == nullptr;
+  ser & wire_is_null;
+  if(!wire_is_null){
+    ser & sstmac::array(wire_buffer_, payload_bytes_);
+  } else {
+    ser & payload_bytes_; 
+  }
 
-  ser & sstmac::array(wire_buffer_, payload_bytes_);
   ser & time_started_;
   ser & time_arrived_;
   ser & injection_started_;
   ser & aid_;
   ser & needs_ack_;
-  ser & payload_bytes_;
   ser & toaddr_;
   ser & fromaddr_;
   ser & type_;
@@ -318,9 +315,6 @@ NetworkMessage::serialize_order(serializer& ser)
   ser.primitive(remote_buffer_);
   ser.primitive(local_buffer_);
   ser.primitive(smsg_buffer_);
-  if (!wire_is_null_) {
-    ser & sstmac::array(wire_buffer_, payload_bytes_);
-    }
 }
 
 #if !SSTMAC_INTEGRATED_SST_CORE

--- a/sstmac/hardware/network/network_message.h
+++ b/sstmac/hardware/network/network_message.h
@@ -387,6 +387,7 @@ class NetworkMessage : public Flow
    * @brief wire_buffer Represents a payload injected on the wire
  */
   void* wire_buffer_ = nullptr;
+  bool wire_is_null_ = false; //only for serialization
 
   sw::AppId aid_;
 

--- a/sstmac/hardware/network/network_message.h
+++ b/sstmac/hardware/network/network_message.h
@@ -387,7 +387,6 @@ class NetworkMessage : public Flow
    * @brief wire_buffer Represents a payload injected on the wire
  */
   void* wire_buffer_ = nullptr;
-  bool wire_is_null_ = false; //only for serialization
 
   sw::AppId aid_;
 

--- a/sumi/collective_actor.cc
+++ b/sumi/collective_actor.cc
@@ -277,33 +277,35 @@ DagCollectiveActor::sendEagerMessage(Action* ac)
 {
   uint64_t num_bytes;
   void* buf = getSendBuffer(ac, num_bytes);
+
+  debug_printf(sumi_collective | sprockit::dbg::sumi,
+   "Rank %s, collective %s(%p) sending eager message to %d on tag=%d offset=%d num_bytes=%d",
+   rankStr().c_str(), toString().c_str(), this,
+   ac->partner, tag_, ac->offset, num_bytes);
+
   /*auto* msg =*/ my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, num_bytes, buf,
                                               cq_id_, cq_id_, Message::collective, engine_->smsgQos(),
                                               type_, dom_me_, ac->partner,
                                               tag_, ac->round, ac->nelems, type_size_,
                                               nullptr, CollectiveWorkMessage::eager);
-
-  debug_printf(sumi_collective | sprockit::dbg::sumi,
-   "Rank %s, collective %s(%p) sending eager message to %d on tag=%d offset=%d",
-   rankStr().c_str(), toString().c_str(), this,
-   ac->partner, tag_, ac->offset);
 }
 
 void
 DagCollectiveActor::sendRdmaPutHeader(Action* ac)
 {
   void* buf = getRecvbuffer(ac);
-  my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, 0, buf,
-                                           Message::no_ack, cq_id_, Message::collective, engine_->rdmaHeaderQos(),
-                                           type_, dom_me_, ac->partner,
-                                           tag_, ac->round,
-                                           ac->nelems, type_size_, buf, CollectiveWorkMessage::put);
 
   debug_printf(sumi_collective | sprockit::dbg::sumi,
    "Rank %s, collective %s(%p) sending put header to %s on round=%d tag=%d offset=%d",
    rankStr().c_str(), toString().c_str(), this,
    rankStr(ac->partner).c_str(),
    ac->round, tag_, ac->offset);
+
+  my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, 0, buf,
+                                           Message::no_ack, cq_id_, Message::collective, engine_->rdmaHeaderQos(),
+                                           type_, dom_me_, ac->partner,
+                                           tag_, ac->round,
+                                           ac->nelems, type_size_, buf, CollectiveWorkMessage::put);
 }
 
 void
@@ -311,16 +313,17 @@ DagCollectiveActor::sendRdmaGetHeader(Action* ac)
 {
   uint64_t num_bytes;
   void* buf = getSendBuffer(ac, num_bytes);
-  my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, 64, //use platform-independent size
-                        buf, Message::no_ack, cq_id_, Message::collective, engine_->rdmaHeaderQos(),
-                        type_, dom_me_, ac->partner,
-                        tag_, ac->round,
-                        ac->nelems, type_size_, buf, CollectiveWorkMessage::get); //do not ack the send
 
   debug_printf(sumi_collective | sprockit::dbg::sumi,
    "Rank %s, collective %s(%p) sending RDMA get header to %d on tag=%d offset=%d",
    rankStr().c_str(), toString().c_str(), this,
    ac->partner, tag_, ac->offset);
+
+  my_api_->smsgSend<CollectiveWorkMessage>(ac->phys_partner, 64, //use platform-independent size
+                        buf, Message::no_ack, cq_id_, Message::collective, engine_->rdmaHeaderQos(),
+                        type_, dom_me_, ac->partner,
+                        tag_, ac->round,
+                        ac->nelems, type_size_, buf, CollectiveWorkMessage::get); //do not ack the send
 }
 
 

--- a/sumi/collective_message.cc
+++ b/sumi/collective_message.cc
@@ -92,7 +92,7 @@ CollectiveWorkMessage::toString() const
   return sprockit::sprintf(
     "message for collective %s recver=%d sender=%d nbytes=%d round=%d tag=%d %s %d->%d",
      Collective::tostr(type_), recver(), sender(), payloadBytes(), round_, tag_,
-     sstmac::hw::NetworkMessage::typeStr(), toaddr(), fromaddr());
+     sstmac::hw::NetworkMessage::typeStr(), fromaddr(), toaddr());
 }
 
 

--- a/sumi/message.h
+++ b/sumi/message.h
@@ -302,12 +302,12 @@ class ProtocolMessage : public Message {
   }
 
   void serialize_order(sstmac::serializer& ser) override {
+    Message::serialize_order(ser);
     ser & stage_;
     ser & protocol_;
     ser & count_;
     ser & type_size_;
     ser.primitive(partner_buffer_);
-    Message::serialize_order(ser);
   }
 
 #if !SSTMAC_INTEGRATED_SST_CORE


### PR DESCRIPTION
Cleaning up the PDES side of the house. Addresses issue #632 and issue #636.
