### PR TITLE
Change should help with running make installcheck

### DIFF
--- a/tests/api/mpi/testexec.in
+++ b/tests/api/mpi/testexec.in
@@ -2,6 +2,7 @@
 
 export PYTHONPATH=$PYTHONPATH:@prefix@/include/python
 export SST_LIB_PATH=@prefix@/lib:$SST_LIB_PATH
+export LD_LIBRARY_PATH=@prefix@/lib:$LD_LIBRARY_PATH
 
 options="$@"
 @sst_prefix@/bin/sst @abs_srcdir@/config.py --model-options="$options"

--- a/tests/api/mpi/testexec.in
+++ b/tests/api/mpi/testexec.in
@@ -2,6 +2,7 @@
 
 export PYTHONPATH=$PYTHONPATH:@prefix@/include/python
 export SST_LIB_PATH=@prefix@/lib:$SST_LIB_PATH
+export DYLD_LIBRARY_PATH=@prefix@/lib:$DYLD_LIBRARY_PATH
 export LD_LIBRARY_PATH=@prefix@/lib:$LD_LIBRARY_PATH
 
 options="$@"


### PR DESCRIPTION
`make installcheck` was failing on our CI because `libmacro.so` couldn't be discovered. 