### PR TITLE
Let's find out if the autotester actually uses these tests

### DIFF
--- a/sstmac/install/Makefile.am
+++ b/sstmac/install/Makefile.am
@@ -75,8 +75,8 @@ SST_REGISTER_TOOL=@sst_prefix@/bin/sst-register
 
 install-exec-hook:
 	  $(SST_REGISTER_TOOL) SST_MACRO SST_MACRO_LIBDIR=@libdir@
-	  #$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE sst-macro=$(abs_srcdir)/../..
-	  #$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS sst-macro=$(abs_srcdir)/../../tests
+	  $(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE sst-macro=$(abs_srcdir)/../..
+	  $(SST_REGISTER_TOOL) SST_ELEMENT_TESTS sst-macro=$(abs_srcdir)/../../tests
 
 endif
 

--- a/sstmac/install/Makefile.am
+++ b/sstmac/install/Makefile.am
@@ -73,12 +73,10 @@ libmacro_la_LDFLAGS = -module -shared -version-info @SSTMAC_LIBVERSION@
 
 SST_REGISTER_TOOL=@sst_prefix@/bin/sst-register
 
-register:
-	  $(SST_REGISTER_TOOL) SST_MACRO SST_MACRO_LIBDIR=@libdir@
-
 install-exec-hook:
-	  $(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE sst-macro=$(abs_srcdir)/../..
-	  $(SST_REGISTER_TOOL) SST_ELEMENT_TESTS sst-macro=$(abs_srcdir)/../../tests
+	  $(SST_REGISTER_TOOL) SST_MACRO SST_MACRO_LIBDIR=@libdir@
+	  #$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE sst-macro=$(abs_srcdir)/../..
+	  #$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS sst-macro=$(abs_srcdir)/../../tests
 
 endif
 


### PR DESCRIPTION
First this is to add the registration of macro to the install hooks.  The second thing is to test removing the registration under the name `SST_ELEMENT_XYZ` to find out if the CI is actually using those variables. 

@jpkenny don't merge if tests pass, I will remove the lines that are commented out. 