### PR TITLE
Fix sstcc

### DIFF
--- a/bin/sstcclib.py
+++ b/bin/sstcclib.py
@@ -490,7 +490,10 @@ def run(typ, extraLibs=""):
       #always use c++ for linking since we are bringing a bunch of sstmac C++ into the game
       ctx.ld = ctx.cxx
     else:
-      ctx.ld = ctx.cc
+      # this mode doesn't work any more (skeletonization uses code that is invalid with C compiler)
+      #ctx.ld = ctx.cc
+      sys.stderr.write("ERROR: Compiling C requires Clang autoskeletonizer\n")
+      sys.exit(1)
     if args.std:
       ctx.cFlags.append("-std=%s" % args.std)
     elif sstCArgs.std:

--- a/bin/sstcclib.py
+++ b/bin/sstcclib.py
@@ -242,8 +242,9 @@ def run(typ, extraLibs=""):
   from sstccvars import clangCppFlagsStr, clangLdFlagsStr
   from sstccutils import cleanFlag, getProcTree, swapSuffix
 
-
-  needfPIC = "fPIC" in sstCxxFlagsStr
+  # Probably better to just always compile PIC
+  #needfPIC = "fPIC" in sstCxxFlagsStr
+  needfPIC = True
 
   sstmacExe = cleanFlag(os.path.join(prefix, "bin", "sstmac"))
 


### PR DESCRIPTION
sstcc now provides a meaningful error if user tries to use it when clang autoskeleton support is not included in build.

Also switch to always compiling -fPIC when using sstcc/sst++.

Addresses issue #660, see issue for further discussion of both changes.