### PR TITLE
remove linkMap.h header (not used)

### DIFF
--- a/sstmac/sst_core/integrated_component.h
+++ b/sstmac/sst_core/integrated_component.h
@@ -49,7 +49,6 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #if SSTMAC_INTEGRATED_SST_CORE
 #include <sst/core/link.h>
-#include <sst/core/linkMap.h>
 #include <sst/core/params.h>
 #include <sst/core/component.h>
 #include <sst/core/subcomponent.h>


### PR DESCRIPTION
Remove linkMap.h header. It's not longer provided by sst-core and isn't used anywhere within macro anyways.
