### PR TITLE
Disabled std::thread replacement. Addresses issue #644

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,8 +30,8 @@ dnl m4_define([SSTMAC_SNAPSHOT_TAG],-beta1)
 m4_define([SSTMAC_ACVERSION_TAG],
           [SSTMAC_VERSION_TAG.SSTMAC_SUBVERSION_TAG.SSTMAC_SUBSUBVERSION_TAG])
 
-dnl AC_PREREQ([2.68]) avoid this if possible
-AC_INIT([sstmacro], [SSTMAC_ACVERSION_TAG], [sst-macro-help@sandia.gov])
+dnl AC_PREREQ([2.71]) avoid this if possible
+AC_INIT([sstmacro],[SSTMAC_ACVERSION_TAG],[sst-macro-help@sandia.gov])
 AC_CONFIG_MACRO_DIR([acinclude])
 AC_CONFIG_AUX_DIR(bin)
 AC_CONFIG_HEADERS(sstmac/common/config.h)
@@ -109,8 +109,8 @@ dnl AC_PROG_RANLIB
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_FC
-AC_LANG_CPLUSPLUS
-AC_PROG_LIBTOOL
+AC_LANG([C++])
+LT_INIT
 
 LT_INIT([shared disable-static dlopen])
 

--- a/sstmac/replacements/mutex
+++ b/sstmac/replacements/mutex
@@ -1,6 +1,8 @@
 #ifndef sstmac_mutex_header_included
 #define sstmac_mutex_header_included
 
+#include <utility>
+
 #ifndef SSTMAC_INSIDE_STL
 #define SSTMAC_INSIDE_STL
 #define MUTEX_OWNS_STL

--- a/sstmac/replacements/thread
+++ b/sstmac/replacements/thread
@@ -1,6 +1,10 @@
 #ifndef sstmac_thread_included
 #define sstmac_thread_included
 
+// Replacing std::thread in this manner was very standards non-compliant
+// and it's broken on newer standard library implementations 
+#if 0
+
 #ifndef SSTMAC_INSIDE_STL
 #define SSTMAC_INSIDE_STL
 #define THREAD_OWNS_STL
@@ -28,6 +32,7 @@ template <class T=void> T yield(){}
 #include <sstmac/replacements/sstmac_pthread_return.h>
 #endif
 
+#endif // end if 0 
 
 #endif
 

--- a/sstmac/software/threading/stack_alloc_chunk.cc
+++ b/sstmac/software/threading/stack_alloc_chunk.cc
@@ -67,7 +67,7 @@ StackAlloc::chunk::chunk(size_t stacksize, size_t suggested_chunk_size, bool pro
 {
   // Now allocate our chunk.
   int mmap_flags = MAP_PRIVATE | MAP_ANON;
-  addr_ = (char*)mmap(0, size_, PROT_READ | PROT_WRITE | PROT_EXEC,
+  addr_ = (char*)mmap(0, size_, PROT_READ | PROT_WRITE,
                       mmap_flags, -1, 0);
   if(addr_ == MAP_FAILED) {
     cerrn << "Failed to mmap a region of size " << size_ << ": "

--- a/tests/Makefile.check_programs
+++ b/tests/Makefile.check_programs
@@ -3,9 +3,10 @@ if !INTEGRATED_SST_CORE
 EXTRA_CPPFLAGS = -I$(top_builddir)/sstmac/replacements \
  -I$(top_srcdir)/sstmac/replacements 
 
-check_PROGRAMS = test_utilities test_pthread test_blas test_std_thread test_tls
+check_PROGRAMS = test_utilities test_pthread test_blas
 test_utilities_SOURCES = test_utilities.cc
 test_utilities_LDADD = $(CORE_LIBS)
+# disable test_std_thread and test_tls because of problems with std::thread replacement
 
 noinst_LTLIBRARIES = libsstmac_test_pthread.la
 test_pthread_SOURCES = dummy_pthread.cc
@@ -23,21 +24,21 @@ test_blas_LDADD = libsstmac_test_blas.la \
   $(CORE_LIBS)
 
 
-noinst_LTLIBRARIES += libsstmac_test_std_thread.la
-test_std_thread_SOURCES = dummy_std_thread.cc
-libsstmac_test_std_thread_la_SOURCES = test_std_thread.cc
-libsstmac_test_std_thread_la_CPPFLAGS = $(EXTRA_CPPFLAGS) $(AM_CPPFLAGS)
-test_std_thread_LDADD = libsstmac_test_std_thread.la \
-  $(top_builddir)/sstmac/main/libsstmac_main.la \
-  $(CORE_LIBS)
+#noinst_LTLIBRARIES += libsstmac_test_std_thread.la
+#test_std_thread_SOURCES = dummy_std_thread.cc
+#libsstmac_test_std_thread_la_SOURCES = test_std_thread.cc
+#libsstmac_test_std_thread_la_CPPFLAGS = $(EXTRA_CPPFLAGS) $(AM_CPPFLAGS)
+#test_std_thread_LDADD = libsstmac_test_std_thread.la \
+#  $(top_builddir)/sstmac/main/libsstmac_main.la \
+#  $(CORE_LIBS)
 
-noinst_LTLIBRARIES += libsstmac_test_tls.la
-test_tls_SOURCES = dummy_tls.cc
-libsstmac_test_tls_la_SOURCES = test_tls.cc
-libsstmac_test_tls_la_CPPFLAGS = $(EXTRA_CPPFLAGS) $(AM_CPPFLAGS)
-test_tls_LDADD = libsstmac_test_tls.la \
-  $(top_builddir)/sstmac/main/libsstmac_main.la \
-  $(CORE_LIBS)
+#noinst_LTLIBRARIES += libsstmac_test_tls.la
+#test_tls_SOURCES = dummy_tls.cc
+#libsstmac_test_tls_la_SOURCES = test_tls.cc
+#libsstmac_test_tls_la_CPPFLAGS = $(EXTRA_CPPFLAGS) $(AM_CPPFLAGS)
+#test_tls_LDADD = libsstmac_test_tls.la \
+#  $(top_builddir)/sstmac/main/libsstmac_main.la \
+#  $(CORE_LIBS)
 
 endif
 

--- a/tests/Makefile.single_tests
+++ b/tests/Makefile.single_tests
@@ -7,9 +7,11 @@ SINGLETESTS = \
   test_utilities \
   test_pthread \
   test_blas \
-  test_std_thread \
-  test_tls \
   test_blas_finegrained 
+# std::thread tests don't work with newer libc++
+# (we were being badly standards non-compliant to make it work and got bit)
+# test_tls could/should be reimplemented using pthread
+#  test_std_thread test_tls
 
 test_utilities.$(CHKSUF): test_utilities
 	$(PYRUNTEST) 6 $(top_srcdir) $@ notime ./test_utilities 


### PR DESCRIPTION
Disable std::thread replacement to address issue #644
Also removes PROT_EXEC memory protection to fix stackalloc mmap issue #672
Also updates configure.ac for newer autoconf
