### PR TITLE
fix segv when printing command line options

### DIFF
--- a/sprockit/sprockit/debug.cc
+++ b/sprockit/sprockit/debug.cc
@@ -224,6 +224,7 @@ normalize_string(const std::string& thestr,
 void
 Debug::printAllDebugSlots(std::ostream& os)
 {
+  checkInit();
   std::string indent = sprockit::sprintf("%22s", "");
   os << "Valid debug flags are:\n";
   std::map<std::string, std::string>::iterator it, end = docstrings_->end();


### PR DESCRIPTION
resolves #706

Accidentally pushed this to the v13.1.0_beta branch.  Can't cherry-pick directly to devel as it's a protected branch.

