### PR TITLE
remove initializeClass() method

### DIFF
--- a/tests/testsuite_default_sst_macro.py
+++ b/tests/testsuite_default_sst_macro.py
@@ -23,11 +23,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_sst_macro(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)


### PR DESCRIPTION
`initializeClass()` is never used across any of our testing.  Its functionality is replicated by `setUpClass()` which is a standard pattern used by unittest.
