### PR TITLE
fix bug in otf2 configuration

### DIFF
--- a/acinclude/check_otf2.m4
+++ b/acinclude/check_otf2.m4
@@ -41,7 +41,7 @@ fi
 
 AM_CONDITIONAL([HAVE_OTF2], [test "x$HAVE_OTF2" = "xyes" -a "X$enable_otf2" != "X$no"])
 
-if test "x$HAVE_OTF2" = "xyes" -a "X$enable_otf2" != "X$no"; then
+if test "x$HAVE_OTF2" = "xyes" -a "X$enable_otf2" != "Xno"; then
 build_otf2=yes
 AC_DEFINE([OTF2_ENABLED],,[Define OTF2 support as enabled])
 else


### PR DESCRIPTION
Fixed buggy autoconf test that resulted in otf2 being enabled anytime the header is detected. The intention was for otf2 to be enabled only when --with-otf2 is given on the command line. PR restores intended function.