### PR TITLE
Stop breaking core includes

### DIFF
--- a/bin/tools/guard_core_includes.sh
+++ b/bin/tools/guard_core_includes.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Define the preamble and postscript text
+preamble="\\
+#ifdef main\\
+#define SSTMAC_SAVE_MAIN main\\
+#undef main\\
+#endif\\
+"
+
+postscript="#ifdef SSTMAC_SAVE_MAIN\\
+#undef main\\
+#define main SSTMAC_SAVE_MAIN\\
+#undef SSTMAC_SAVE_MAIN\\
+#endif\\
+\\
+"
+
+# Use find to locate files and sed to modify them
+find . -type f -exec sed -i '' "/#include.*sst\/core/i\\
+$preamble" {} \;
+find . -type f -exec sed -i '' "/#include.*sst\/core/a\\
+$postscript"  {} \;

--- a/skeletons/sst_component_example/component.cc
+++ b/skeletons/sst_component_example/component.cc
@@ -86,8 +86,30 @@ class TestModule : public SSTElementPythonModule {
    SST_ELI_ELEMENT_VERSION(1,0,0)
   )
 };
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/model/element_python.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/element.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #endif
 
 /**

--- a/sprockit/sprockit/sim_parameters.h
+++ b/sprockit/sprockit/sim_parameters.h
@@ -58,8 +58,30 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include <sstmac/common/sstmac_config.h>
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/params.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/unitAlgebra.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #else
 namespace SST {
 class Params;

--- a/sstmac/common/event_handler.h
+++ b/sstmac/common/event_handler.h
@@ -53,7 +53,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <tuple>
 
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/link.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #endif
 
 namespace sstmac {

--- a/sstmac/common/serializable.h
+++ b/sstmac/common/serializable.h
@@ -48,10 +48,54 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/common/sstmac_config.h>
 
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/serialization/serializer_fwd.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/serialization/serializable.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/serialization/serialize_serializable.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/serialization/serializer.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 
 #define START_SERIALIZATION_NAMESPACE namespace SST { namespace Core { namespace Serialization {
 #define END_SERIALIZATION_NAMESPACE } } }

--- a/sstmac/common/sst_event.h
+++ b/sstmac/common/sst_event.h
@@ -51,7 +51,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/common/event_scheduler_fwd.h>
 #include <sstmac/common/event_location.h>
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/event.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #endif
 
 namespace sstmac {

--- a/sstmac/common/stats/stat_collector.h
+++ b/sstmac/common/stats/stat_collector.h
@@ -56,8 +56,30 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sprockit/sim_parameters_fwd.h>
 
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/statapi/statbase.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/statapi/statoutput.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #else
 #include <sprockit/factory.h>
 #endif

--- a/sstmac/common/timestamp.h
+++ b/sstmac/common/timestamp.h
@@ -53,7 +53,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sprockit/errors.h>
 
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/sst_types.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #endif
 
 namespace sstmac {

--- a/sstmac/hardware/merlin/merlin_nic.cc
+++ b/sstmac/hardware/merlin/merlin_nic.cc
@@ -58,7 +58,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/hardware/sculpin/sculpin_switch.h>
 #include <sstmac/hardware/common/recv_cq.h>
 
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/interfaces/simpleNetwork.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 
 #include <stddef.h>
 

--- a/sstmac/hardware/sculpin/sculpin_switch.cc
+++ b/sstmac/hardware/sculpin/sculpin_switch.cc
@@ -59,7 +59,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/hardware/topology/topology.h>
 #include <sstmac/common/event_callback.h>
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/factory.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #endif
 RegisterNamespaces("switch", "router", "xbar", "link");
 

--- a/sstmac/hardware/sculpin/sculpin_switch.h
+++ b/sstmac/hardware/sculpin/sculpin_switch.h
@@ -51,7 +51,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/common/stats/stat_collector.h>
 #if SSTMAC_VTK_ENABLED
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/sst_types.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #include <sstmac/hardware/vtk/vtk_stats.h>
 #else
 #include <sstmac/hardware/vtk/vtk_stats.h>

--- a/sstmac/hardware/snappr/snappr_switch.cc
+++ b/sstmac/hardware/snappr/snappr_switch.cc
@@ -61,7 +61,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/common/stats/ftq_tag.h>
 #include <sstmac/common/event_callback.h>
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/factory.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #endif
 RegisterNamespaces("switch", "router", "xbar", "link");
 

--- a/sstmac/hardware/vtk/statoutputexodus.cc
+++ b/sstmac/hardware/vtk/statoutputexodus.cc
@@ -44,7 +44,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sst_config.h>
 
 #include <sstmac/hardware/vtk/statoutputexodus.h>
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/statapi/statgroup.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #include <sstmac/hardware/vtk/stattraffic.h>
 #include <sstmac/hardware/vtk/vtk_stats.h>
 #include <sstmac/hardware/topology/topology.h>

--- a/sstmac/hardware/vtk/statoutputexodus.h
+++ b/sstmac/hardware/vtk/statoutputexodus.h
@@ -44,9 +44,31 @@ Questions? Contact sst-macro-help@sandia.gov
 #ifndef SSTMAC_HW_VTK_STATISTICS_OUTPUT_EXODUS
 #define SSTMAC_HW_VTK_STATISTICS_OUTPUT_EXODUS
 
-#include "sst/core/sst_types.h"
 
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
+#include "sst/core/sst_types.h"
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/statapi/statoutput.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #include <sstmac/hardware/vtk/vtk_stats.h>
 
 namespace sstmac {

--- a/sstmac/hardware/vtk/stattraffic.h
+++ b/sstmac/hardware/vtk/stattraffic.h
@@ -47,13 +47,79 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <cmath>
 #include <limits>
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
 
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
+#include <sst/core/sst_types.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
+#include <sst/core/warnmacros.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/statapi/statfieldinfo.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/statapi/statoutput.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/statapi/statbase.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/baseComponent.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #include "statoutputexodus.h"
 
 namespace sstmac {

--- a/sstmac/hardware/vtk/vtk_stats.h
+++ b/sstmac/hardware/vtk/vtk_stats.h
@@ -52,8 +52,30 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/hardware/topology/topology.h>
 
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/statapi/statfieldinfo.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 //#include <sst/core/sst_types.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 using namespace SST;
 #endif
 namespace sstmac {

--- a/sstmac/replacements/thread
+++ b/sstmac/replacements/thread
@@ -1,6 +1,8 @@
 #ifndef sstmac_thread_included
 #define sstmac_thread_included
 
+#include_next <thread>
+
 // Replacing std::thread in this manner was very standards non-compliant
 // and it's broken on newer standard library implementations 
 #if 0

--- a/sstmac/software/api/api.h
+++ b/sstmac/software/api/api.h
@@ -59,7 +59,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sys/time.h>
 
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/subcomponent.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #endif
 
 namespace sstmac {

--- a/sstmac/sst_core/integrated_component.h
+++ b/sstmac/sst_core/integrated_component.h
@@ -48,11 +48,66 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/common/sstmac_config.h>
 
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/link.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/params.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/component.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/subcomponent.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/eli/elibase.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 
 #define SSTMAC_VALID_PORTS \
    {"input%(in)d",  "Will receive new payloads here",      {}}, \

--- a/sstmac/sst_core/integrated_core.cc
+++ b/sstmac/sst_core/integrated_core.cc
@@ -45,7 +45,18 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/common/sstmac_config.h>
 #include <sstmac/main/sstmac.h>
 
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/model/element_python.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 
 #include <sstmac/common/event_scheduler.h>
 #include <sstmac/sst_core/integrated_core.h>

--- a/sstmac/sst_core/integrated_core.h
+++ b/sstmac/sst_core/integrated_core.h
@@ -47,7 +47,18 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include <sst_config.h>
 
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/params.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 
 #include <unordered_map>
 #include <sprockit/sim_parameters.h>

--- a/sstmac/sst_core/partitioner.cc
+++ b/sstmac/sst_core/partitioner.cc
@@ -42,9 +42,31 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Questions? Contact sst-macro-help@sandia.gov
 */
 
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/sstpart.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #include <sst_config.h>
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/configGraph.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #include <sprockit/sim_parameters.h>
 #include <sstmac/backends/common/sim_partition.h>
 #include <sstmac/backends/common/parallel_runtime.h>

--- a/sumi/sim_transport.cc
+++ b/sumi/sim_transport.cc
@@ -83,7 +83,18 @@ RegisterKeywords(
 
 #include <sstmac/common/sstmac_config.h>
 #if SSTMAC_INTEGRATED_SST_CORE
+
+#ifdef main
+#define SSTMAC_SAVE_MAIN main
+#undef main
+#endif
 #include <sst/core/event.h>
+#ifdef SSTMAC_SAVE_MAIN
+#undef main
+#define main SSTMAC_SAVE_MAIN
+#undef SSTMAC_SAVE_MAIN
+#endif
+
 #endif
 #include <sumi/sim_transport.h>
 #include <sumi/message.h>


### PR DESCRIPTION
Fixes two issues that were breaking core header includes.
1) avoid rewriting main for core header includes
2) don't break thread header for standard library
