### PR TITLE
Update for upcoming SST 16 Release

### DIFF
--- a/acinclude/check_std.m4
+++ b/acinclude/check_std.m4
@@ -18,7 +18,7 @@ AC_ARG_WITH(std,
     cxxstd=$withval
   ],
   [
-    cxxstd=11
+    cxxstd=17
   ]
 )
 

--- a/skeletons/sst_component_example/component.cc
+++ b/skeletons/sst_component_example/component.cc
@@ -221,11 +221,11 @@ class DummySwitch : public TestComponent {
   }
 
   LinkHandler* creditHandler(int port) override {
-    return newLinkHandler(this, &DummySwitch::recvCredit);
+    return newLinkHandler<DummySwitch, &DummySwitch::recvCredit>(this);
   }
 
   LinkHandler* payloadHandler(int port) override {
-    return newLinkHandler(this, &DummySwitch::recvPayload);
+    return newLinkHandler<DummySwitch, &DummySwitch::recvPayload>(this);
   }
 
  private:

--- a/sprockit/sprockit/serialize.h
+++ b/sprockit/sprockit/serialize.h
@@ -150,6 +150,17 @@ operator&(serializer& ser, T& t){
   serialize<T>()(t, ser);
 }
 
+// Single-argument entry point: serialize 'x' using the in-scope serializer.
+template <class T>
+inline void sst_ser_helper(sprockit::serializer& ser, T& x)
+{
+  // Calls sprockit::operator&(serializer&, T&/T*&/void*)
+  sprockit::operator&(ser, x);
+}
+
+// macro form that only takes the item-to-serialize.
+#define SST_SER(x) sst_ser_helper(ser, (x))
+
 }
 
 #include <sprockit/serialize_array.h>

--- a/sprockit/sprockit/serialize_array.h
+++ b/sprockit/sprockit/serialize_array.h
@@ -102,6 +102,13 @@ operator&(serializer& ser, pvt::ser_array_wrapper<TPtr,IntType> arr){
   ser.binary(arr.bufptr, arr.sizeptr);
 }
 
+template <class TPtr, class IntType>
+inline void
+sst_ser_helper(sprockit::serializer& ser, pvt::ser_array_wrapper<TPtr,IntType> arr)
+{
+  ser.binary(arr.bufptr, arr.sizeptr);
+}
+
 // Needed only because the default version in serialize.h can't get
 // the template expansions quite right trying to look through several
 // levels of expansion

--- a/sprockit/sprockit/sim_parameters.h
+++ b/sprockit/sprockit/sim_parameters.h
@@ -654,14 +654,14 @@ template <> class serialize<SST::Params>
   void operator()(SST::Params& p, serializer& ser){
     if (ser.mode() == ser.UNPACK){
       std::string paramStr;
-      ser & paramStr;
+      SST_SER(paramStr);
       std::stringstream sstr(paramStr);
       p->parseStream(sstr, false, true);
     } else {
       std::stringstream sstr;
       p->reproduceParams(sstr);
       std::string paramStr = sstr.str();
-      ser & paramStr;
+      SST_SER(paramStr);
     }
   }
 };

--- a/sstmac/backends/common/parallel_runtime.cc
+++ b/sstmac/backends/common/parallel_runtime.cc
@@ -314,13 +314,13 @@ ParallelRuntime::~ParallelRuntime()
 void
 ParallelRuntime::runSerialize(serializer& ser, IpcEvent* iev)
 {
-  ser & iev->ser_size; //this must be first!!!
-  ser & iev->thread; //this must be first!!!
-  ser & iev->t;
-  ser & iev->seqnum;
-  ser & iev->link;
-  ser & iev->rank;
-  ser & iev->ev;
+  SST_SER(iev->ser_size); //this must be first!!!
+  SST_SER(iev->thread); //this must be first!!!
+  SST_SER(iev->t);
+  SST_SER(iev->seqnum);
+  SST_SER(iev->link);
+  SST_SER(iev->rank);
+  SST_SER(iev->ev);
 }
 
 void ParallelRuntime::sendEvent(IpcEvent* iev)
@@ -338,7 +338,7 @@ void ParallelRuntime::sendEvent(IpcEvent* iev)
 
   sprockit::serializer ser;
   ser.start_sizing();
-  ser & iev->ev;
+  SST_SER(iev->ev);
   iev->ser_size = overhead + ser.size();
   align64(iev->ser_size);
   CommBuffer& buff = send_buffers_[iev->rank];

--- a/sstmac/backends/native/clock_cycle_event_container.cc
+++ b/sstmac/backends/native/clock_cycle_event_container.cc
@@ -100,8 +100,8 @@ ClockCycleEventMap::handleIncoming(char* buf)
   ser.start_unpacking(buf, 1<<31); //just pass in a huge number
   uint32_t sz; //these are guaranteed to be first
   uint32_t thread;
-  ser & sz;
-  ser & thread;
+  SST_SER(sz;
+  SST_SER(thread;
   if (sz == 0){
     sprockit::abort("got zero size for incoming buffer");
   }

--- a/sstmac/common/event_handler.h
+++ b/sstmac/common/event_handler.h
@@ -115,7 +115,7 @@ public:
     static constexpr bool value = type::value;
 };
 
-template <class Cls, typename Fxn, class ...Args>
+template <class Cls, auto Fxn, typename dataT = void>
 class MemberFxnHandler : public EventHandler
 {
 
@@ -127,20 +127,18 @@ class MemberFxnHandler : public EventHandler
   }
 
   void handle(Event* ev) override {
-    dispatch(ev, typename gens<sizeof...(Args)>::type());
+    dispatch(ev);
   }
 
-  MemberFxnHandler(Cls* obj, Fxn fxn, const Args&... args) :
-    params_(args...),
-    fxn_(fxn),
+  MemberFxnHandler(Cls* obj) :
     obj_(obj)
   {
   }
 
  private:
   template <int ...S>
-  void dispatch(Event* ev, seq<S...>){
-    (obj_->*fxn_)(ev, std::get<S>(params_)...);
+  void dispatch(Event* ev){
+    (obj_->*Fxn)(ev);
   }
 
   template <class T = Cls>
@@ -163,17 +161,14 @@ class MemberFxnHandler : public EventHandler
   typename std::enable_if<!has_deadlock_check<T>::value>::type
   localDeadlockCheck(Event*) {}
 
-  std::tuple<Args...> params_;
-  Fxn fxn_;
   Cls* obj_;
 
 };
 
-template<class Cls, typename Fxn, class ...Args>
-EventHandler* newHandler(Cls* cls, Fxn fxn, const Args&... args)
+template<class Cls, auto Fxn, typename dataT = void>
+EventHandler* newHandler(Cls* cls)
 {
-  return new MemberFxnHandler<Cls, Fxn, Args...>(
-        cls, fxn, args...);
+  return new MemberFxnHandler<Cls, Fxn, dataT>(cls);
 }
 
 

--- a/sstmac/common/event_scheduler.cc
+++ b/sstmac/common/event_scheduler.cc
@@ -73,7 +73,6 @@ EventLink::~EventLink()
 }
 
 #if SSTMAC_INTEGRATED_SST_CORE
-SST::TimeConverter* SharedBaseComponent::time_converter_ = nullptr;
 
 IntegratedComponent::IntegratedComponent(uint32_t id) :
   IntegratedBaseComponent<SST::Component>("self", id)

--- a/sstmac/common/event_scheduler.h
+++ b/sstmac/common/event_scheduler.h
@@ -228,7 +228,7 @@ class SharedBaseComponent {
     return time_converter_;
   }
  protected:
-  static SST::TimeConverter time_converter_;
+  static inline SST::TimeConverter time_converter_ = {};
 #endif
 };
 

--- a/sstmac/common/event_scheduler.h
+++ b/sstmac/common/event_scheduler.h
@@ -95,9 +95,9 @@ class EventLink : public serializable {
   }
 
   void serialize_order(serializer& ser) override {
-    ser & link_;
-    ser & selflat_;
-    ser & name_;
+    SST_SER(link_);
+    SST_SER(selflat_);
+    SST_SER(name_);
   }
 
   ImplementSerializable(EventLink);

--- a/sstmac/common/event_scheduler.h
+++ b/sstmac/common/event_scheduler.h
@@ -45,6 +45,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #ifndef SSTMAC_COMMON_EventScheduler_H_INCLUDED
 #define SSTMAC_COMMON_EventScheduler_H_INCLUDED
 
+#include <sstmac/common/serializable.h>
 #include <sstmac/common/timestamp.h>
 #include <sstmac/common/event_handler.h>
 #include <sstmac/common/handler_event_queue_entry.h>
@@ -65,7 +66,7 @@ extern int run_standalone(int, char**);
 namespace sstmac {
   using LinkHandler = SST::Event::HandlerBase;
 
-class EventLink {
+class EventLink : public serializable {
  public:
   EventLink(const std::string& name, TimeDelta selflat, SST::Link* link) :
     link_(link),
@@ -73,6 +74,8 @@ class EventLink {
     name_(name)
   {
   }
+
+  EventLink() = default;
 
   using ptr = std::unique_ptr<EventLink>;
 
@@ -90,6 +93,14 @@ class EventLink {
   void send(Event* ev){
     send(selflat_, ev);
   }
+
+  void serialize_order(serializer& ser) override {
+    ser & link_;
+    ser & selflat_;
+    ser & name_;
+  }
+
+  ImplementSerializable(EventLink);
 
  private:
   SST::Link* link_;
@@ -213,11 +224,11 @@ class SharedBaseComponent {
 
 #if SSTMAC_INTEGRATED_SST_CORE
  public:
-  static SST::TimeConverter* timeConverter() {
+  static SST::TimeConverter timeConverter() {
     return time_converter_;
   }
  protected:
-  static SST::TimeConverter* time_converter_;
+  static SST::TimeConverter time_converter_;
 #endif
 };
 
@@ -249,7 +260,7 @@ class IntegratedBaseComponent :
     return dynamic_cast<T*>(sub);
   }
 
-  SST::SimTime_t getCurrentSimTime(SST::TimeConverter* tc) const {
+  SST::SimTime_t getCurrentSimTime(SST::TimeConverter tc) const {
     return Base::getCurrentSimTime(tc);
   }
 
@@ -295,7 +306,7 @@ protected:
      time_converter_ = Base::getTimeConverter(TimeDelta::tickIntervalString());
    }
    self_link_ = Base::configureSelfLink(selfname, time_converter_,
-         new SST::Event::Handler<IntegratedBaseComponent>(this, &IntegratedBaseComponent::handleExecutionEvent));
+         new SST::Event::Handler<IntegratedBaseComponent, &IntegratedBaseComponent::handleExecutionEvent>(this));
  }
 
  private:
@@ -505,15 +516,14 @@ class SubComponent : public SubComponentParent
 };
 
 #if SSTMAC_INTEGRATED_SST_CORE
-template <class T, class Fxn>
-SST::Event::HandlerBase* newLinkHandler(const T* t, Fxn fxn){
-  return new SST::Event::Handler<T>(const_cast<T*>(t), fxn);
+template <typename T, auto funcT, typename dataT = void>
+SST::Event::HandlerBase* newLinkHandler(const T* t){
+  return new SST::Event::Handler<T, funcT, dataT>(const_cast<T*>(t));
 }
 #else
-template <class T, class Fxn, class... Args>
-SST::Event::HandlerBase* newLinkHandler(const T* t, Fxn fxn, Args&&... args){
-  return new MemberFxnHandler<T, Fxn, Args...>(
-        const_cast<T*>(t), fxn, std::forward<Args>(args)...);
+template <class T, auto Fxn, typename dataT = void>
+SST::Event::HandlerBase* newLinkHandler(const T* t){
+  return new MemberFxnHandler<T, Fxn, dataT>(const_cast<T*>(t));
 }
 
 class LocalLink : public EventLink {

--- a/sstmac/common/serializable.h
+++ b/sstmac/common/serializable.h
@@ -77,7 +77,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #define SSTMAC_SAVE_MAIN main
 #undef main
 #endif
-#include <sst/core/serialization/serialize_serializable.h>
+#include <sst/core/serialization/serializable.h>
 #ifdef SSTMAC_SAVE_MAIN
 #undef main
 #define main SSTMAC_SAVE_MAIN
@@ -123,7 +123,7 @@ using SST::Core::Serialization::raw_ptr;
 #else
 #include <sprockit/serializer_fwd.h>
 #include <sprockit/serializable.h>
-#include <sprockit/serialize_serializable.h>
+#include <sprockit/serializable.h>
 #include <sprockit/serializer.h>
 
 namespace SST {

--- a/sstmac/common/timestamp.h
+++ b/sstmac/common/timestamp.h
@@ -108,8 +108,8 @@ class TimeDelta
  public:
 
   void serialize_order(SST::Core::Serialization::serializer& ser) {
-    ser& ticks_;
-    ser& max_time_;
+    SST_SER(ticks_);
+    SST_SER(max_time_);
   }
 
   static void initStamps(tick_t tick_spacing);
@@ -256,8 +256,8 @@ struct Timestamp
   TimeDelta time;
 
   void serialize_order(SST::Core::Serialization::serializer& ser) {
-    ser& epochs;
-    ser& time;
+    SST_SER(epochs);
+    SST_SER(time);
   }
 
   static constexpr uint64_t carry_bits_mask = 0;

--- a/sstmac/hardware/common/flow.h
+++ b/sstmac/hardware/common/flow.h
@@ -85,9 +85,9 @@ class Flow : public Request
   }
 
   void serialize_order(sstmac::serializer& ser) override {
-    ser & flow_id_;
-    ser & byte_length_;
-    ser & libname_;
+    SST_SER(flow_id_);
+    SST_SER(byte_length_);
+    SST_SER(libname_);
   }
 
  protected:

--- a/sstmac/hardware/common/packet.cc
+++ b/sstmac/hardware/common/packet.cc
@@ -76,15 +76,15 @@ void
 Packet::serialize_order(serializer& ser)
 {
   Event::serialize_order(ser);
-  ser & toaddr_;
-  ser & fromaddr_;
-  ser & flow_id_;
-  ser & num_bytes_;
-  ser & qos_;
-  ser & payload_;
-  ser & rtr_metadata_;
-  ser & stats_metadata_;
-  ser & nic_metadata_;
+  SST_SER(toaddr_);
+  SST_SER(fromaddr_);
+  SST_SER(flow_id_);
+  SST_SER(num_bytes_);
+  SST_SER(qos_);
+  SST_SER(payload_);
+  SST_SER(rtr_metadata_);
+  SST_SER(stats_metadata_);
+  SST_SER(nic_metadata_);
 }
 
 }

--- a/sstmac/hardware/common/unique_id.h
+++ b/sstmac/hardware/common/unique_id.h
@@ -102,8 +102,8 @@ struct UniqueEventId {
   }
 
   void serialize_order(SST::Core::Serialization::serializer& ser) {
-    ser& src_node;
-    ser& msg_num;
+    SST_SER(src_node);
+    SST_SER(msg_num);
   }
 };
 

--- a/sstmac/hardware/logp/logp_nic.cc
+++ b/sstmac/hardware/logp/logp_nic.cc
@@ -130,7 +130,7 @@ LogPNIC::connectInput(int /*src_outport*/, int /*dst_inport*/,
 LinkHandler*
 LogPNIC::payloadHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &NIC::mtlHandle);
+  return newLinkHandler<NIC, &NIC::mtlHandle>(this);
 }
 
 }

--- a/sstmac/hardware/logp/logp_nic.h
+++ b/sstmac/hardware/logp/logp_nic.h
@@ -96,7 +96,7 @@ class LogPNIC :
   }
 
   LinkHandler* creditHandler(int  /*port*/) override {
-    return newLinkHandler(this, &LogPNIC::dropEvent);
+    return newLinkHandler<LogPNIC, &LogPNIC::dropEvent>(this);
   }
 
   LinkHandler* payloadHandler(int port) override;

--- a/sstmac/hardware/logp/logp_switch.h
+++ b/sstmac/hardware/logp/logp_switch.h
@@ -105,11 +105,11 @@ class LogPSwitch : public ConnectableComponent
   void connectInput(int, int, EventLink::ptr&&) override {}
 
   LinkHandler* payloadHandler(int  /*port*/) override {
-    return newLinkHandler(this, &LogPSwitch::sendEvent);
+    return newLinkHandler<LogPSwitch, &LogPSwitch::sendEvent>(this);
   }
 
   LinkHandler* creditHandler(int  /*port*/) override {
-    return newLinkHandler(this, &LogPSwitch::dropEvent);
+    return newLinkHandler<LogPSwitch, &LogPSwitch::dropEvent>(this);
   }
 
   void connectOutput(NodeId nid, EventLink::ptr&& link) {

--- a/sstmac/hardware/merlin/merlin_nic.cc
+++ b/sstmac/hardware/merlin/merlin_nic.cc
@@ -145,8 +145,8 @@ class MerlinNIC :
     ack_queue_.resize(vns_);
     mtu_ = params.find<SST::UnitAlgebra>("mtu").getRoundedValue();
 
-    auto recv_notify = new SST::Interfaces::SimpleNetwork::Handler<MerlinNIC>(this,&MerlinNIC::incomingPacket);
-    auto send_notify = new SST::Interfaces::SimpleNetwork::Handler<MerlinNIC>(this,&MerlinNIC::incomingCredit);
+    auto recv_notify = new SST::Interfaces::SimpleNetwork::Handler<MerlinNIC, &MerlinNIC::incomingPacket>(this);
+    auto send_notify = new SST::Interfaces::SimpleNetwork::Handler<MerlinNIC, &MerlinNIC::incomingCredit>(this);
 
     if (params.contains("test_size")){
       test_size_ = params.find<SST::UnitAlgebra>("test_size").getRoundedValue();

--- a/sstmac/hardware/network/network_message.cc
+++ b/sstmac/hardware/network/network_message.cc
@@ -288,27 +288,27 @@ NetworkMessage::serialize_order(serializer& ser)
 
   // Can't serialize a nullptr!
   bool wire_is_null = wire_buffer_ == nullptr;
-  ser & wire_is_null;
+  SST_SER(wire_is_null);
   if(!wire_is_null){
-    ser & sstmac::array(wire_buffer_, payload_bytes_);
+    SST_SER(sstmac::array(wire_buffer_, payload_bytes_));
   } else {
-    ser & payload_bytes_; 
+    SST_SER(payload_bytes_); 
   }
 
-  ser & time_started_;
-  ser & time_arrived_;
-  ser & injection_started_;
-  ser & aid_;
-  ser & needs_ack_;
-  ser & toaddr_;
-  ser & fromaddr_;
-  ser & type_;
-  ser & qos_;
-  ser & time_started_;
-  ser & injection_started_;
-  ser & injection_delay_;
-  ser & min_delay_;
-  ser & congestion_delay_;
+  SST_SER(time_started_);
+  SST_SER(time_arrived_);
+  SST_SER(injection_started_);
+  SST_SER(aid_);
+  SST_SER(needs_ack_);
+  SST_SER(toaddr_);
+  SST_SER(fromaddr_);
+  SST_SER(type_);
+  SST_SER(qos_);
+  SST_SER(time_started_);
+  SST_SER(injection_started_);
+  SST_SER(injection_delay_);
+  SST_SER(min_delay_);
+  SST_SER(congestion_delay_);
   if (type_ == null_netmsg_type){
     spkt_abort_printf("failed serializing network message - got null type");
   }

--- a/sstmac/hardware/nic/nic.cc
+++ b/sstmac/hardware/nic/nic.cc
@@ -80,7 +80,7 @@ void
 NicEvent::serialize_order(serializer &ser)
 {
   Event::serialize_order(ser);
-  ser & msg_;
+  SST_SER(msg_);
 }
 
 #if !SSTMAC_INTEGRATED_SST_CORE

--- a/sstmac/hardware/nic/nic.cc
+++ b/sstmac/hardware/nic/nic.cc
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Questions? Contact sst-macro-help@sandia.gov
 */
 
+#include <sstmac/common/event_handler.h>
 #include <sstmac/hardware/nic/nic.h>
 #include <sstmac/hardware/interconnect/interconnect.h>
 #include <sstmac/hardware/network/network_message.h>
@@ -144,9 +145,9 @@ NIC::~NIC()
 }
 
 EventHandler*
-NIC::mtlHandler() const
+NIC::mtlHandler()
 {
-  return newHandler(const_cast<NIC*>(this), &NIC::mtlHandle);
+  return newHandler<NIC, &NIC::mtlHandle>(this);
 }
 
 void

--- a/sstmac/hardware/nic/nic.h
+++ b/sstmac/hardware/nic/nic.h
@@ -144,7 +144,7 @@ class NIC : public ConnectableSubcomponent
    */
   void injectSend(NetworkMessage* netmsg);
 
-  EventHandler* mtlHandler() const;
+  EventHandler* mtlHandler();
 
   virtual void mtlHandle(Event* ev);
 

--- a/sstmac/hardware/pisces/pisces.cc
+++ b/sstmac/hardware/pisces/pisces.cc
@@ -75,8 +75,8 @@ PiscesPacket::serialize_order(serializer& ser)
 {
   //routable::serialize_order(ser);
   Packet::serialize_order(ser);
-  ser & arrival_;
-  ser & current_vc_;
+  SST_SER(arrival_);
+  SST_SER(current_vc_);
 }
 
 std::string
@@ -101,9 +101,9 @@ void
 PiscesCredit::serialize_order(serializer& ser)
 {
   Event::serialize_order(ser);
-  ser & num_credits_;
-  ser & port_;
-  ser & vc_;
+  SST_SER(num_credits_);
+  SST_SER(port_);
+  SST_SER(vc_);
 }
 
 }

--- a/sstmac/hardware/pisces/pisces_branched_switch.cc
+++ b/sstmac/hardware/pisces/pisces_branched_switch.cc
@@ -44,6 +44,8 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include <string>
 
+#include <pisces/pisces_crossbar.h>
+#include <sstmac/common/event_scheduler.h>
 #include <sstmac/hardware/pisces/pisces_branched_switch.h>
 #include <sstmac/hardware/pisces/pisces_nic.h>
 #include <sstmac/hardware/topology/structured_topology.h>
@@ -182,7 +184,7 @@ LinkHandler*
 PiscesBranchedSwitch::creditHandler(int port)
 {
   PiscesDemuxer* demux = output_demuxers_[port];
-  return newLinkHandler(demux, &PiscesDemuxer::handlePayload);
+  return newLinkHandler<PiscesNtoMQueue, &PiscesNtoMQueue::handlePayload>(demux);
 }
 
 void
@@ -212,7 +214,7 @@ LinkHandler*
 PiscesBranchedSwitch::payloadHandler(int port)
 {
   InputPort* mux = const_cast<InputPort*>(&input_muxers_[port]);
-  return newLinkHandler(mux, &InputPort::handle);
+  return newLinkHandler<InputPort, &InputPort::handle>(mux);
 }
 
 }

--- a/sstmac/hardware/pisces/pisces_branched_switch.h
+++ b/sstmac/hardware/pisces/pisces_branched_switch.h
@@ -105,8 +105,8 @@ class PiscesBranchedSwitch :
     }
 
     void serialize_order(serializer& ser) {
-      ser & parent;
-      ser & mux;
+      SST_SER(parent);
+      SST_SER(mux);
     }
   };
 

--- a/sstmac/hardware/pisces/pisces_branched_switch.h
+++ b/sstmac/hardware/pisces/pisces_branched_switch.h
@@ -45,6 +45,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #ifndef pisces_BRANCHED_SWITCH_H
 #define pisces_BRANCHED_SWITCH_H
 
+#include <sstmac/common/serializable.h>
 #include <sstmac/hardware/pisces/pisces_switch.h>
 #include <sstmac/hardware/pisces/pisces_buffer.h>
 #include <sstmac/hardware/pisces/pisces_crossbar.h>
@@ -101,6 +102,11 @@ class PiscesBranchedSwitch :
 
     std::string toString() const {
       return parent->toString();
+    }
+
+    void serialize_order(serializer& ser) {
+      ser & parent;
+      ser & mux;
     }
   };
 

--- a/sstmac/hardware/pisces/pisces_crossbar.cc
+++ b/sstmac/hardware/pisces/pisces_crossbar.cc
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Questions? Contact sst-macro-help@sandia.gov
 */
 
+#include <sstmac/common/event_scheduler.h>
 #include <sstmac/hardware/pisces/pisces_crossbar.h>
 #include <sstmac/hardware/pisces/pisces_tiled_switch.h>
 #include <sstmac/hardware/topology/structured_topology.h>
@@ -108,13 +109,13 @@ PiscesNtoMQueue(const std::string& selfname, uint32_t id,
 LinkHandler*
 PiscesNtoMQueue::creditHandler()
 {
-  return newLinkHandler(this, &PiscesNtoMQueue::handleCredit);
+  return newLinkHandler<PiscesNtoMQueue, &PiscesNtoMQueue::handleCredit>(this);
 }
 
 LinkHandler*
 PiscesNtoMQueue::payloadHandler()
 {
-  return newLinkHandler(this, &PiscesNtoMQueue::handlePayload);
+  return newLinkHandler<PiscesNtoMQueue, &PiscesNtoMQueue::handlePayload>(this);
 }
 
 PiscesNtoMQueue::~PiscesNtoMQueue()

--- a/sstmac/hardware/pisces/pisces_nic.cc
+++ b/sstmac/hardware/pisces/pisces_nic.cc
@@ -67,7 +67,7 @@ PiscesNIC::PiscesNIC(uint32_t id, SST::Params& params, Node* parent) :
   pending_inject_(1)
 {
   SST::Params inj_params = params.get_scoped_params("injection");
-  self_mtl_link_ = allocateSubLink("mtl", TimeDelta(), newLinkHandler(this, &NIC::mtlHandle));
+  self_mtl_link_ = allocateSubLink("mtl", TimeDelta(), newLinkHandler<NIC, &NIC::mtlHandle>(this));
 
   inj_credits_ = inj_params.find<SST::UnitAlgebra>("credits").getRoundedValue();
   auto arb = inj_params.find<std::string>("arbitrator");
@@ -102,16 +102,16 @@ LinkHandler*
 PiscesNIC::payloadHandler(int port)
 {
   if (port == NIC::LogP){
-    return newLinkHandler(this, &NIC::mtlHandle);
+    return newLinkHandler<NIC, &NIC::mtlHandle>(this);
   } else {
-    return newLinkHandler(this, &PiscesNIC::incomingPacket);
+    return newLinkHandler<PiscesNIC, &PiscesNIC::incomingPacket>(this);
   }
 }
 
 LinkHandler*
 PiscesNIC::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &PiscesNIC::packetSent);
+  return newLinkHandler<PiscesNIC, &PiscesNIC::packetSent>(this);
 }
 
 void

--- a/sstmac/hardware/pisces/pisces_switch.cc
+++ b/sstmac/hardware/pisces/pisces_switch.cc
@@ -42,6 +42,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Questions? Contact sst-macro-help@sandia.gov
 */
 
+#include <pisces/pisces_buffer.h>
+#include <pisces/pisces_sender.h>
+#include <sstmac/common/event_scheduler.h>
 #include <sstmac/hardware/switch/network_switch.h>
 #include <sstmac/hardware/pisces/pisces_switch.h>
 #include <sstmac/hardware/nic/nic.h>
@@ -169,7 +172,7 @@ PiscesSwitch::connectOutput(
   int buffer_inport = 0;
   std::string out_port_name = sprockit::sprintf("buffer-out%d", src_outport);
   auto out_link = allocateSubLink(out_port_name, TimeDelta(), //don't put latency on xbar
-                    newLinkHandler(out_buffer, &PiscesBuffer::handlePayload));
+  newLinkHandler<PiscesBuffer, &PiscesBuffer::handlePayload>(out_buffer));
   xbar_->setOutput(src_outport, buffer_inport, std::move(out_link), link_credits_ * scale_factor);
 
   std::string in_port_name = sprockit::sprintf("xbar-credit%d", src_outport);
@@ -231,14 +234,14 @@ PiscesSwitch::creditHandler(int port)
     spkt_abort_printf("Got invalid port %d request for credit handler - max is %d",
                       port, out_buffers_.size() - 1);
   }
-  return newLinkHandler(out_buffers_[port], &PiscesSender::handleCredit);
+  return newLinkHandler<PiscesSender, &PiscesSender::handleCredit>(out_buffers_[port]);
 }
 
 LinkHandler*
 PiscesSwitch::payloadHandler(int port)
 {
   InputPort* inp = &inports_[port];
-  return newLinkHandler(inp, &InputPort::handle);
+  return newLinkHandler<InputPort, &InputPort::handle>(inp);
 }
 
 }

--- a/sstmac/hardware/pisces/pisces_switch.h
+++ b/sstmac/hardware/pisces/pisces_switch.h
@@ -135,9 +135,9 @@ class PiscesSwitch :
     }
 
     void serialize_order(serializer& ser) {
-      ser & parent;
-      ser & recv_bytes_;
-      ser & port;
+      SST_SER(parent);
+      SST_SER(recv_bytes_);
+      SST_SER(port);
     }
   };
 

--- a/sstmac/hardware/pisces/pisces_switch.h
+++ b/sstmac/hardware/pisces/pisces_switch.h
@@ -133,6 +133,12 @@ class PiscesSwitch :
     std::string toString() const {
       return parent->xbar()->toString();
     }
+
+    void serialize_order(serializer& ser) {
+      ser & parent;
+      ser & recv_bytes_;
+      ser & port;
+    }
   };
 
   std::vector<PiscesBuffer*> out_buffers_;

--- a/sstmac/hardware/pisces/pisces_tiled_switch.cc
+++ b/sstmac/hardware/pisces/pisces_tiled_switch.cc
@@ -44,6 +44,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include <string>
 
+#include <sstmac/common/event_scheduler.h>
 #include <sstmac/hardware/pisces/pisces_tiled_switch.h>
 #include <sstmac/hardware/pisces/pisces_nic.h>
 #include <sstmac/hardware/topology/structured_topology.h>
@@ -263,13 +264,13 @@ PiscesTiledSwitch::toString() const
 LinkHandler*
 PiscesTiledSwitch::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &PiscesTiledSwitch::handleCredit);
+  return newLinkHandler<PiscesTiledSwitch, &PiscesTiledSwitch::handleCredit>(this);
 }
 
 LinkHandler*
 PiscesTiledSwitch::payloadHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &PiscesTiledSwitch::handlePayload);
+  return newLinkHandler<PiscesTiledSwitch, &PiscesTiledSwitch::handlePayload>(this);
 }
 
 }

--- a/sstmac/hardware/sculpin/sculpin.cc
+++ b/sstmac/hardware/sculpin/sculpin.cc
@@ -82,9 +82,9 @@ SculpinPacket::serialize_order(serializer& ser)
 {
   //routable::serialize_order(ser);
   Packet::serialize_order(ser);
-  ser & arrival_;
-  ser & time_to_send_;
-  ser & priority_;
+  SST_SER(arrival_);
+  SST_SER(time_to_send_);
+  SST_SER(priority_);
 }
 
 }

--- a/sstmac/hardware/sculpin/sculpin_nic.cc
+++ b/sstmac/hardware/sculpin/sculpin_nic.cc
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Questions? Contact sst-macro-help@sandia.gov
 */
 
+#include <sstmac/common/event_scheduler.h>
 #include <sstmac/hardware/topology/structured_topology.h>
 #include <sstmac/hardware/network/network_message.h>
 #include <sstmac/hardware/sculpin/sculpin_nic.h>
@@ -93,16 +94,16 @@ LinkHandler*
 SculpinNIC::payloadHandler(int port)
 {
   if (port == NIC::LogP){
-    return newLinkHandler(this, &NIC::mtlHandle);
+    return newLinkHandler<NIC, &NIC::mtlHandle>(this);
   } else {
-    return newLinkHandler(this, &SculpinNIC::handlePayload);
+    return newLinkHandler<SculpinNIC, &SculpinNIC::handlePayload>(this);
   }
 }
 
 LinkHandler*
 SculpinNIC::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &SculpinNIC::handleCredit);
+  return newLinkHandler<SculpinNIC, &SculpinNIC::handleCredit>(this);
 }
 
 void

--- a/sstmac/hardware/sculpin/sculpin_switch.cc
+++ b/sstmac/hardware/sculpin/sculpin_switch.cc
@@ -48,6 +48,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include <inttypes.h>
 
+#include <sstmac/common/event_scheduler.h>
 #include <sstmac/hardware/router/router.h>
 #include <sstmac/hardware/switch/network_switch.h>
 #include <sstmac/hardware/sculpin/sculpin_switch.h>
@@ -339,13 +340,13 @@ SculpinSwitch::toString() const
 LinkHandler*
 SculpinSwitch::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &SculpinSwitch::handleCredit);
+  return newLinkHandler<SculpinSwitch, &SculpinSwitch::handleCredit>(this);
 }
 
 LinkHandler*
 SculpinSwitch::payloadHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &SculpinSwitch::handlePayload);
+  return newLinkHandler<SculpinSwitch, &SculpinSwitch::handlePayload>(this);
 }
 
 }

--- a/sstmac/hardware/snappr/snappr.cc
+++ b/sstmac/hardware/snappr/snappr.cc
@@ -87,16 +87,16 @@ void
 SnapprPacket::serialize_order(serializer& ser)
 {
   Packet::serialize_order(ser);
-  ser & seqnum_;
-  ser & arrival_;
-  ser & time_to_send_;
-  ser & congestion_delay_;
-  ser & offset_;
-  ser & vl_;
-  ser & priority_;
-  ser & inport_;
-  ser & input_vl_;
-  ser & deadlocked_;
+  SST_SER(seqnum_);
+  SST_SER(arrival_);
+  SST_SER(time_to_send_);
+  SST_SER(congestion_delay_);
+  SST_SER(offset_);
+  SST_SER(vl_);
+  SST_SER(priority_);
+  SST_SER(inport_);
+  SST_SER(input_vl_);
+  SST_SER(deadlocked_);
 }
 
 std::string
@@ -108,9 +108,9 @@ void
 SnapprCredit::serialize_order(serializer &ser)
 {
   Event::serialize_order(ser);
-  ser & num_bytes_;
-  ser & port_;
-  ser & vl_;
+  SST_SER(num_bytes_);
+  SST_SER(port_);
+  SST_SER(vl_);
 }
 
 }

--- a/sstmac/hardware/snappr/snappr_inport.h
+++ b/sstmac/hardware/snappr/snappr_inport.h
@@ -45,13 +45,14 @@ Questions? Contact sst-macro-help@sandia.gov
 #ifndef snappr_inport_h
 #define snappr_inport_h
 
+#include <sstmac/common/serializable.h>
 #include <sstmac/common/event_scheduler.h>
 #include <sstmac/hardware/snappr/snappr_switch_fwd.h>
 
 namespace sstmac {
 namespace hw {
 
-struct SnapprInPort {
+struct SnapprInPort : public serializable {
   int number;
   int src_outport;
   EventLink::ptr link;
@@ -59,6 +60,16 @@ struct SnapprInPort {
   void handle(Event* ev);
 
   std::string toString() const;
+
+  void serialize_order(serializer& ser) override {
+    ser & number;
+    ser & src_outport;
+    ser & link.get();  // the get is required for sprockit serialization
+    // SnapprSwitch is abstract
+    // ser & parent);
+  }
+
+  ImplementSerializable(SnapprInPort);
 };
 
 }

--- a/sstmac/hardware/snappr/snappr_inport.h
+++ b/sstmac/hardware/snappr/snappr_inport.h
@@ -62,9 +62,9 @@ struct SnapprInPort : public serializable {
   std::string toString() const;
 
   void serialize_order(serializer& ser) override {
-    ser & number;
-    ser & src_outport;
-    ser & link.get();  // the get is required for sprockit serialization
+    SST_SER(number);
+    SST_SER(src_outport);
+    SST_SER(*link);
     // SnapprSwitch is abstract
     // ser & parent);
   }
@@ -76,4 +76,3 @@ struct SnapprInPort : public serializable {
 }
 
 #endif
-

--- a/sstmac/hardware/snappr/snappr_inport.h
+++ b/sstmac/hardware/snappr/snappr_inport.h
@@ -52,7 +52,7 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace sstmac {
 namespace hw {
 
-struct SnapprInPort : public serializable {
+struct SnapprInPort {
   int number;
   int src_outport;
   EventLink::ptr link;
@@ -61,15 +61,13 @@ struct SnapprInPort : public serializable {
 
   std::string toString() const;
 
-  void serialize_order(serializer& ser) override {
+  void serialize_order(serializer& ser) {
     SST_SER(number);
     SST_SER(src_outport);
     SST_SER(*link);
     // SnapprSwitch is abstract
-    // ser & parent);
+    // SST_SER(parent);
   }
-
-  ImplementSerializable(SnapprInPort);
 };
 
 }

--- a/sstmac/hardware/snappr/snappr_nic.cc
+++ b/sstmac/hardware/snappr/snappr_nic.cc
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Questions? Contact sst-macro-help@sandia.gov
 */
 
+#include <sstmac/common/event_scheduler.h>
 #include <sumi-mpi/mpi_message.h>
 #include <sstmac/hardware/topology/structured_topology.h>
 #include <sstmac/hardware/network/network_message.h>
@@ -169,9 +170,9 @@ LinkHandler*
 SnapprNIC::payloadHandler(int port)
 {
   if (port == NIC::LogP){
-    return newLinkHandler(this, &NIC::mtlHandle);
+    return newLinkHandler<NIC, &NIC::mtlHandle>(this);
   } else {
-    return newLinkHandler(this, &SnapprNIC::handlePayload);
+    return newLinkHandler<SnapprNIC, &SnapprNIC::handlePayload>(this);
   }
 }
 
@@ -188,7 +189,7 @@ SnapprNIC::deadlockCheck()
 LinkHandler*
 SnapprNIC::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &SnapprNIC::handleCredit);
+  return newLinkHandler<SnapprNIC, &SnapprNIC::handleCredit>(this);
 }
 
 void

--- a/sstmac/hardware/snappr/snappr_switch.cc
+++ b/sstmac/hardware/snappr/snappr_switch.cc
@@ -48,6 +48,9 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include <inttypes.h>
 
+#include <snappr/snappr_inport.h>
+#include <snappr/snappr_outport.h>
+#include <sstmac/common/event_scheduler.h>
 #include <sstmac/hardware/router/router.h>
 #include <sstmac/hardware/switch/network_switch.h>
 #include <sstmac/hardware/snappr/snappr_switch.h>
@@ -306,14 +309,14 @@ LinkHandler*
 SnapprSwitch::creditHandler(int port)
 {
   switch_debug("returning credit handler on output port %d", port);
-  return newLinkHandler(outports_[port], &SnapprOutPort::handle);
+  return newLinkHandler<SnapprOutPort, &SnapprOutPort::handle>(outports_[port]);
 }
 
 LinkHandler*
 SnapprSwitch::payloadHandler(int port)
 {
   switch_debug("returning payload handler on input port %d", port);
-  return newLinkHandler(&inports_[port], &SnapprInPort::handle);
+  return newLinkHandler<SnapprInPort, &SnapprInPort::handle>(&inports_[port]);
 }
 
 

--- a/sstmac/skeletons/offered_load/main.cc
+++ b/sstmac/skeletons/offered_load/main.cc
@@ -77,9 +77,9 @@ class RdmaMessage :
   }
 
   void serialize_order(sstmac::serializer& ser) override {
-    ser & iter_;
-    ser & start_;
-    ser & finish_;
+    SST_SER( iter_ );
+    SST_SER( start_ );
+    SST_SER( finish_ );
     sumi::Message::serialize_order(ser);
   }
 

--- a/sstmac/software/launch/app_launcher.cc
+++ b/sstmac/software/launch/app_launcher.cc
@@ -137,8 +137,8 @@ void
 StartAppRequest::serialize_order(serializer &ser)
 {
   LaunchRequest::serialize_order(ser);
-  ser & unique_name_;
-  ser & app_params_;
+  SST_SER(unique_name_);
+  SST_SER(app_params_);
   mapping_ = TaskMapping::serialize_order(aid(), ser);
 }
 

--- a/sstmac/software/launch/launch_event.h
+++ b/sstmac/software/launch/launch_event.h
@@ -71,8 +71,8 @@ class LaunchRequest : public hw::NetworkMessage
 
   void serialize_order(serializer& ser) override {
     hw::NetworkMessage::serialize_order(ser);
-    ser & ty_;
-    ser & tid_;
+    SST_SER(ty_);
+    SST_SER(tid_);
   }
 
   TaskId tid() const {

--- a/sstmac/software/launch/task_mapping.cc
+++ b/sstmac/software/launch/task_mapping.cc
@@ -60,9 +60,9 @@ TaskMapping::serialize_order(AppId aid, serializer &ser)
   TaskMapping::ptr mapping;
   if (ser.mode() == ser.UNPACK){
     int num_nodes;
-    ser & num_nodes;
+    SST_SER(num_nodes);
     mapping = std::make_shared<TaskMapping>(aid);
-    ser & mapping->rank_to_node_indexing_;
+    SST_SER(mapping->rank_to_node_indexing_);
     mapping->node_to_rank_indexing_.resize(num_nodes);
     int num_ranks = mapping->rank_to_node_indexing_.size();
     for (int i=0; i < num_ranks; ++i){
@@ -82,8 +82,8 @@ TaskMapping::serialize_order(AppId aid, serializer &ser)
     mapping = app_ids_launched_[aid];
     if (!mapping) spkt_abort_printf("no task mapping exists for application %d", aid);
     int num_nodes = mapping->node_to_rank_indexing_.size();
-    ser & num_nodes;
-    ser & mapping->rank_to_node_indexing_;
+    SST_SER(num_nodes);
+    SST_SER(mapping->rank_to_node_indexing_);
   }
   return mapping;
 }

--- a/sumi-mpi/mpi_message.cc
+++ b/sumi-mpi/mpi_message.cc
@@ -59,12 +59,12 @@ void
 MpiMessage::serialize_order(sstmac::serializer& ser)
 {
   ProtocolMessage::serialize_order(ser);
-  ser & (src_rank_);
-  ser & (dst_rank_);
-  ser & type_;
-  ser & (tag_);
-  ser & (commid_);
-  ser & (seqnum_);
+  SST_SER(src_rank_);
+  SST_SER(dst_rank_);
+  SST_SER(type_);
+  SST_SER(tag_);
+  SST_SER(commid_);
+  SST_SER(seqnum_);
 }
 
 #if !SSTMAC_INTEGRATED_SST_CORE

--- a/sumi/collective_message.cc
+++ b/sumi/collective_message.cc
@@ -66,11 +66,11 @@ void
 CollectiveWorkMessage::serialize_order(sstmac::serializer &ser)
 {
   ProtocolMessage::serialize_order(ser);
-  ser & tag_;
-  ser & type_;
-  ser & round_;
-  ser & dom_recver_;
-  ser & dom_sender_;
+  SST_SER( tag_ );
+  SST_SER( type_ );
+  SST_SER( round_ );
+  SST_SER( dom_recver_ );
+  SST_SER( dom_sender_ );
 }
 
 #if !SSTMAC_INTEGRATED_SST_CORE

--- a/sumi/message.cc
+++ b/sumi/message.cc
@@ -84,13 +84,13 @@ Message::tostr(class_t ty)
 void
 Message::serialize_order(sstmac::serializer &ser)
 {
-  ser & arrived_;
-  ser & recv_sync_delay_;
-  ser & sender_;
-  ser & recver_;
-  ser & class_;
-  ser & send_cq_;
-  ser & recv_cq_;
+  SST_SER(arrived_);
+  SST_SER(recv_sync_delay_);
+  SST_SER(sender_);
+  SST_SER(recver_);
+  SST_SER(class_);
+  SST_SER(send_cq_);
+  SST_SER(recv_cq_);
   NetworkMessage::serialize_order(ser);
 }
 

--- a/sumi/message.h
+++ b/sumi/message.h
@@ -303,10 +303,10 @@ class ProtocolMessage : public Message {
 
   void serialize_order(sstmac::serializer& ser) override {
     Message::serialize_order(ser);
-    ser & stage_;
-    ser & protocol_;
-    ser & count_;
-    ser & type_size_;
+    SST_SER(stage_);
+    SST_SER(protocol_);
+    SST_SER(count_);
+    SST_SER(type_size_);
     ser.primitive(partner_buffer_);
   }
 


### PR DESCRIPTION
Update for upcoming SST 16 Release

* update cxxstd to 17
* update `newLinkHandler` template
* update `sstmac/common/event_handler.h` template parameters
* made `EventLink`, `PiscesBranchedSwitch`, `InputPort`, `SnapprInPort` serializable
* update `TimeConverter *` to `TimeConverter` (without pointer)
* update `SST::Event::Handler` template
