### PR TITLE
Updated to match the changes to sst-core

### DIFF
--- a/skeletons/sst_component_example/component.cc
+++ b/skeletons/sst_component_example/component.cc
@@ -221,11 +221,11 @@ class DummySwitch : public TestComponent {
   }
 
   LinkHandler* creditHandler(int port) override {
-    return newLinkHandler(this, &DummySwitch::recvCredit);
+    return newLinkHandler<&DummySwitch::recvCredit>(this);
   }
 
   LinkHandler* payloadHandler(int port) override {
-    return newLinkHandler(this, &DummySwitch::recvPayload);
+    return newLinkHandler<&DummySwitch::recvPayload>(this);
   }
 
  private:

--- a/sstmac/common/event_scheduler.cc
+++ b/sstmac/common/event_scheduler.cc
@@ -73,7 +73,7 @@ EventLink::~EventLink()
 }
 
 #if SSTMAC_INTEGRATED_SST_CORE
-SST::TimeConverter* SharedBaseComponent::time_converter_ = nullptr;
+SST::TimeConverter SharedBaseComponent::time_converter_;
 
 IntegratedComponent::IntegratedComponent(uint32_t id) :
   IntegratedBaseComponent<SST::Component>("self", id)

--- a/sstmac/common/event_scheduler.h
+++ b/sstmac/common/event_scheduler.h
@@ -213,11 +213,11 @@ class SharedBaseComponent {
 
 #if SSTMAC_INTEGRATED_SST_CORE
  public:
-  static SST::TimeConverter* timeConverter() {
+  static SST::TimeConverter timeConverter() {
     return time_converter_;
   }
  protected:
-  static SST::TimeConverter* time_converter_;
+  static SST::TimeConverter time_converter_;
 #endif
 };
 
@@ -249,7 +249,7 @@ class IntegratedBaseComponent :
     return dynamic_cast<T*>(sub);
   }
 
-  SST::SimTime_t getCurrentSimTime(SST::TimeConverter* tc) const {
+  SST::SimTime_t getCurrentSimTime(SST::TimeConverter tc) const {
     return Base::getCurrentSimTime(tc);
   }
 
@@ -295,7 +295,7 @@ protected:
      time_converter_ = Base::getTimeConverter(TimeDelta::tickIntervalString());
    }
    self_link_ = Base::configureSelfLink(selfname, time_converter_,
-         new SST::Event::Handler<IntegratedBaseComponent>(this, &IntegratedBaseComponent::handleExecutionEvent));
+         new SST::Event::Handler<IntegratedBaseComponent, &IntegratedBaseComponent::handleExecutionEvent>(this));
  }
 
  private:
@@ -504,12 +504,27 @@ class SubComponent : public SubComponentParent
   }
 };
 
+namespace detail {
+template <typename> struct handler_class;
+template <typename C, typename R, typename... Args>
+struct handler_class<R(C::*)(Args...)> { using type = C; };
+template <typename C, typename R, typename... Args>
+struct handler_class<R(C::*)(Args...) const> { using type = C; };
+}
+
 #if SSTMAC_INTEGRATED_SST_CORE
-template <class T, class Fxn>
-SST::Event::HandlerBase* newLinkHandler(const T* t, Fxn fxn){
-  return new SST::Event::Handler<T>(const_cast<T*>(t), fxn);
+template <auto Fxn, class T>
+SST::Event::HandlerBase* newLinkHandler(const T* t){
+  using FxnClass = typename detail::handler_class<decltype(Fxn)>::type;
+  return new SST::Event::Handler<FxnClass, Fxn>(
+      const_cast<FxnClass*>(static_cast<const FxnClass*>(t)));
 }
 #else
+template <auto Fxn, class T>
+SST::Event::HandlerBase* newLinkHandler(const T* t){
+  return new MemberFxnHandler<T, decltype(Fxn)>(const_cast<T*>(t), Fxn);
+}
+
 template <class T, class Fxn, class... Args>
 SST::Event::HandlerBase* newLinkHandler(const T* t, Fxn fxn, Args&&... args){
   return new MemberFxnHandler<T, Fxn, Args...>(

--- a/sstmac/common/serializable.h
+++ b/sstmac/common/serializable.h
@@ -48,6 +48,7 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <sstmac/common/sstmac_config.h>
 
 #if SSTMAC_INTEGRATED_SST_CORE
+#include <utility>
 
 #ifdef main
 #define SSTMAC_SAVE_MAIN main
@@ -77,18 +78,6 @@ Questions? Contact sst-macro-help@sandia.gov
 #define SSTMAC_SAVE_MAIN main
 #undef main
 #endif
-#include <sst/core/serialization/serialize_serializable.h>
-#ifdef SSTMAC_SAVE_MAIN
-#undef main
-#define main SSTMAC_SAVE_MAIN
-#undef SSTMAC_SAVE_MAIN
-#endif
-
-
-#ifdef main
-#define SSTMAC_SAVE_MAIN main
-#undef main
-#endif
 #include <sst/core/serialization/serializer.h>
 #ifdef SSTMAC_SAVE_MAIN
 #undef main
@@ -96,6 +85,16 @@ Questions? Contact sst-macro-help@sandia.gov
 #undef SSTMAC_SAVE_MAIN
 #endif
 
+// SST devel removed serialize_serializable.h; sst-macro still uses stream-style
+// `ser & member` in serialize_order bodies. Route through the same gateway as SST_SER.
+namespace SST::Core::Serialization {
+template <typename T>
+serializer& operator&(serializer& ser, T&& obj)
+{
+    pvt::sst_ser_object(ser, std::forward<T>(obj), 0, "");
+    return ser;
+}
+} // namespace SST::Core::Serialization
 
 #define START_SERIALIZATION_NAMESPACE namespace SST { namespace Core { namespace Serialization {
 #define END_SERIALIZATION_NAMESPACE } } }

--- a/sstmac/hardware/logp/logp_nic.cc
+++ b/sstmac/hardware/logp/logp_nic.cc
@@ -130,7 +130,7 @@ LogPNIC::connectInput(int /*src_outport*/, int /*dst_inport*/,
 LinkHandler*
 LogPNIC::payloadHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &NIC::mtlHandle);
+  return newLinkHandler<&NIC::mtlHandle>(this);
 }
 
 }

--- a/sstmac/hardware/logp/logp_nic.h
+++ b/sstmac/hardware/logp/logp_nic.h
@@ -96,7 +96,7 @@ class LogPNIC :
   }
 
   LinkHandler* creditHandler(int  /*port*/) override {
-    return newLinkHandler(this, &LogPNIC::dropEvent);
+    return newLinkHandler<&LogPNIC::dropEvent>(this);
   }
 
   LinkHandler* payloadHandler(int port) override;

--- a/sstmac/hardware/logp/logp_switch.h
+++ b/sstmac/hardware/logp/logp_switch.h
@@ -105,11 +105,11 @@ class LogPSwitch : public ConnectableComponent
   void connectInput(int, int, EventLink::ptr&&) override {}
 
   LinkHandler* payloadHandler(int  /*port*/) override {
-    return newLinkHandler(this, &LogPSwitch::sendEvent);
+    return newLinkHandler<&LogPSwitch::sendEvent>(this);
   }
 
   LinkHandler* creditHandler(int  /*port*/) override {
-    return newLinkHandler(this, &LogPSwitch::dropEvent);
+    return newLinkHandler<&LogPSwitch::dropEvent>(this);
   }
 
   void connectOutput(NodeId nid, EventLink::ptr&& link) {

--- a/sstmac/hardware/merlin/merlin_nic.cc
+++ b/sstmac/hardware/merlin/merlin_nic.cc
@@ -145,8 +145,10 @@ class MerlinNIC :
     ack_queue_.resize(vns_);
     mtu_ = params.find<SST::UnitAlgebra>("mtu").getRoundedValue();
 
-    auto recv_notify = new SST::Interfaces::SimpleNetwork::Handler<MerlinNIC>(this,&MerlinNIC::incomingPacket);
-    auto send_notify = new SST::Interfaces::SimpleNetwork::Handler<MerlinNIC>(this,&MerlinNIC::incomingCredit);
+    auto recv_notify =
+      new SST::Interfaces::SimpleNetwork::Handler<MerlinNIC, &MerlinNIC::incomingPacket>(this);
+    auto send_notify =
+      new SST::Interfaces::SimpleNetwork::Handler<MerlinNIC, &MerlinNIC::incomingCredit>(this);
 
     if (params.contains("test_size")){
       test_size_ = params.find<SST::UnitAlgebra>("test_size").getRoundedValue();

--- a/sstmac/hardware/node/simple_node.cc
+++ b/sstmac/hardware/node/simple_node.cc
@@ -78,7 +78,7 @@ SimpleNode::SimpleNode(uint32_t id, SST::Params& params)
   unblock_links_.resize(ncores);
   for (int i=0; i < ncores; ++i){
     std::string linkName = "unblock" + std::to_string(i);
-    unblock_links_[i] = configureLink(linkName, new Event::Handler<SimpleNode>(this, &SimpleNode::unblock));
+    unblock_links_[i] = configureLink(linkName, new Event::Handler<SimpleNode, &SimpleNode::unblock>(this));
   }
 #endif
 }

--- a/sstmac/hardware/pisces/pisces_branched_switch.cc
+++ b/sstmac/hardware/pisces/pisces_branched_switch.cc
@@ -182,7 +182,7 @@ LinkHandler*
 PiscesBranchedSwitch::creditHandler(int port)
 {
   PiscesDemuxer* demux = output_demuxers_[port];
-  return newLinkHandler(demux, &PiscesDemuxer::handlePayload);
+  return newLinkHandler<&PiscesDemuxer::handlePayload>(demux);
 }
 
 void
@@ -212,7 +212,7 @@ LinkHandler*
 PiscesBranchedSwitch::payloadHandler(int port)
 {
   InputPort* mux = const_cast<InputPort*>(&input_muxers_[port]);
-  return newLinkHandler(mux, &InputPort::handle);
+  return newLinkHandler<&InputPort::handle>(mux);
 }
 
 }

--- a/sstmac/hardware/pisces/pisces_branched_switch.h
+++ b/sstmac/hardware/pisces/pisces_branched_switch.h
@@ -99,6 +99,8 @@ class PiscesBranchedSwitch :
 
     void handle(Event* ev);
 
+    void serialize_order(sstmac::serializer& UNUSED(ser)) {}
+
     std::string toString() const {
       return parent->toString();
     }

--- a/sstmac/hardware/pisces/pisces_crossbar.cc
+++ b/sstmac/hardware/pisces/pisces_crossbar.cc
@@ -108,13 +108,13 @@ PiscesNtoMQueue(const std::string& selfname, uint32_t id,
 LinkHandler*
 PiscesNtoMQueue::creditHandler()
 {
-  return newLinkHandler(this, &PiscesNtoMQueue::handleCredit);
+  return newLinkHandler<&PiscesNtoMQueue::handleCredit>(this);
 }
 
 LinkHandler*
 PiscesNtoMQueue::payloadHandler()
 {
-  return newLinkHandler(this, &PiscesNtoMQueue::handlePayload);
+  return newLinkHandler<&PiscesNtoMQueue::handlePayload>(this);
 }
 
 PiscesNtoMQueue::~PiscesNtoMQueue()

--- a/sstmac/hardware/pisces/pisces_nic.cc
+++ b/sstmac/hardware/pisces/pisces_nic.cc
@@ -67,7 +67,7 @@ PiscesNIC::PiscesNIC(uint32_t id, SST::Params& params, Node* parent) :
   pending_inject_(1)
 {
   SST::Params inj_params = params.get_scoped_params("injection");
-  self_mtl_link_ = allocateSubLink("mtl", TimeDelta(), newLinkHandler(this, &NIC::mtlHandle));
+  self_mtl_link_ = allocateSubLink("mtl", TimeDelta(), newLinkHandler<&NIC::mtlHandle>(this));
 
   inj_credits_ = inj_params.find<SST::UnitAlgebra>("credits").getRoundedValue();
   auto arb = inj_params.find<std::string>("arbitrator");
@@ -102,16 +102,16 @@ LinkHandler*
 PiscesNIC::payloadHandler(int port)
 {
   if (port == NIC::LogP){
-    return newLinkHandler(this, &NIC::mtlHandle);
+    return newLinkHandler<&NIC::mtlHandle>(this);
   } else {
-    return newLinkHandler(this, &PiscesNIC::incomingPacket);
+    return newLinkHandler<&PiscesNIC::incomingPacket>(this);
   }
 }
 
 LinkHandler*
 PiscesNIC::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &PiscesNIC::packetSent);
+  return newLinkHandler<&PiscesNIC::packetSent>(this);
 }
 
 void

--- a/sstmac/hardware/pisces/pisces_switch.cc
+++ b/sstmac/hardware/pisces/pisces_switch.cc
@@ -169,7 +169,7 @@ PiscesSwitch::connectOutput(
   int buffer_inport = 0;
   std::string out_port_name = sprockit::sprintf("buffer-out%d", src_outport);
   auto out_link = allocateSubLink(out_port_name, TimeDelta(), //don't put latency on xbar
-                    newLinkHandler(out_buffer, &PiscesBuffer::handlePayload));
+                    newLinkHandler<&PiscesBuffer::handlePayload>(out_buffer));
   xbar_->setOutput(src_outport, buffer_inport, std::move(out_link), link_credits_ * scale_factor);
 
   std::string in_port_name = sprockit::sprintf("xbar-credit%d", src_outport);
@@ -231,14 +231,14 @@ PiscesSwitch::creditHandler(int port)
     spkt_abort_printf("Got invalid port %d request for credit handler - max is %d",
                       port, out_buffers_.size() - 1);
   }
-  return newLinkHandler(out_buffers_[port], &PiscesSender::handleCredit);
+  return newLinkHandler<&PiscesSender::handleCredit>(out_buffers_[port]);
 }
 
 LinkHandler*
 PiscesSwitch::payloadHandler(int port)
 {
   InputPort* inp = &inports_[port];
-  return newLinkHandler(inp, &InputPort::handle);
+  return newLinkHandler<&InputPort::handle>(inp);
 }
 
 }

--- a/sstmac/hardware/pisces/pisces_switch.h
+++ b/sstmac/hardware/pisces/pisces_switch.h
@@ -130,6 +130,9 @@ class PiscesSwitch :
 
     void handle(Event* ev);
 
+ 
+    void serialize_order(sstmac::serializer& UNUSED(ser)) {}
+
     std::string toString() const {
       return parent->xbar()->toString();
     }

--- a/sstmac/hardware/pisces/pisces_tiled_switch.cc
+++ b/sstmac/hardware/pisces/pisces_tiled_switch.cc
@@ -263,13 +263,13 @@ PiscesTiledSwitch::toString() const
 LinkHandler*
 PiscesTiledSwitch::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &PiscesTiledSwitch::handleCredit);
+  return newLinkHandler<&PiscesTiledSwitch::handleCredit>(this);
 }
 
 LinkHandler*
 PiscesTiledSwitch::payloadHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &PiscesTiledSwitch::handlePayload);
+  return newLinkHandler<&PiscesTiledSwitch::handlePayload>(this);
 }
 
 }

--- a/sstmac/hardware/sculpin/sculpin_nic.cc
+++ b/sstmac/hardware/sculpin/sculpin_nic.cc
@@ -93,16 +93,16 @@ LinkHandler*
 SculpinNIC::payloadHandler(int port)
 {
   if (port == NIC::LogP){
-    return newLinkHandler(this, &NIC::mtlHandle);
+    return newLinkHandler<&NIC::mtlHandle>(this);
   } else {
-    return newLinkHandler(this, &SculpinNIC::handlePayload);
+    return newLinkHandler<&SculpinNIC::handlePayload>(this);
   }
 }
 
 LinkHandler*
 SculpinNIC::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &SculpinNIC::handleCredit);
+  return newLinkHandler<&SculpinNIC::handleCredit>(this);
 }
 
 void

--- a/sstmac/hardware/sculpin/sculpin_switch.cc
+++ b/sstmac/hardware/sculpin/sculpin_switch.cc
@@ -339,13 +339,13 @@ SculpinSwitch::toString() const
 LinkHandler*
 SculpinSwitch::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &SculpinSwitch::handleCredit);
+  return newLinkHandler<&SculpinSwitch::handleCredit>(this);
 }
 
 LinkHandler*
 SculpinSwitch::payloadHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &SculpinSwitch::handlePayload);
+  return newLinkHandler<&SculpinSwitch::handlePayload>(this);
 }
 
 }

--- a/sstmac/hardware/snappr/snappr_inport.h
+++ b/sstmac/hardware/snappr/snappr_inport.h
@@ -58,6 +58,8 @@ struct SnapprInPort {
   SnapprSwitch* parent;
   void handle(Event* ev);
 
+  void serialize_order(sstmac::serializer& UNUSED(ser)) {}
+
   std::string toString() const;
 };
 

--- a/sstmac/hardware/snappr/snappr_nic.cc
+++ b/sstmac/hardware/snappr/snappr_nic.cc
@@ -169,9 +169,9 @@ LinkHandler*
 SnapprNIC::payloadHandler(int port)
 {
   if (port == NIC::LogP){
-    return newLinkHandler(this, &NIC::mtlHandle);
+    return newLinkHandler<&NIC::mtlHandle>(this);
   } else {
-    return newLinkHandler(this, &SnapprNIC::handlePayload);
+    return newLinkHandler<&SnapprNIC::handlePayload>(this);
   }
 }
 
@@ -188,7 +188,7 @@ SnapprNIC::deadlockCheck()
 LinkHandler*
 SnapprNIC::creditHandler(int  /*port*/)
 {
-  return newLinkHandler(this, &SnapprNIC::handleCredit);
+  return newLinkHandler<&SnapprNIC::handleCredit>(this);
 }
 
 void

--- a/sstmac/hardware/snappr/snappr_switch.cc
+++ b/sstmac/hardware/snappr/snappr_switch.cc
@@ -306,14 +306,14 @@ LinkHandler*
 SnapprSwitch::creditHandler(int port)
 {
   switch_debug("returning credit handler on output port %d", port);
-  return newLinkHandler(outports_[port], &SnapprOutPort::handle);
+  return newLinkHandler<&SnapprOutPort::handle>(outports_[port]);
 }
 
 LinkHandler*
 SnapprSwitch::payloadHandler(int port)
 {
   switch_debug("returning payload handler on input port %d", port);
-  return newLinkHandler(&inports_[port], &SnapprInPort::handle);
+  return newLinkHandler<&SnapprInPort::handle>(&inports_[port]);
 }
 
 

--- a/sstmac/sst_core/integrated_core.cc
+++ b/sstmac/sst_core/integrated_core.cc
@@ -280,11 +280,11 @@ static void* gen_sst_macro_integrated_pymodule(void)
   PyObject* nproc_fxn = PyObject_GetAttrString(mainModule, "getMPIRankCount");
   PyObject* nthr_fxn = PyObject_GetAttrString(mainModule, "getThreadCount");
 
-  PyObject* nthr_py = PyEval_CallObject(nthr_fxn, NULL);
+  PyObject* nthr_py = PyObject_CallObject(nthr_fxn, nullptr);
   int nthread = PyInt_AsLong(nthr_py);
   Py_DECREF(nthr_py);
   Py_DECREF(nthr_fxn);
-  PyObject* nproc_py = PyEval_CallObject(nproc_fxn, NULL);
+  PyObject* nproc_py = PyObject_CallObject(nproc_fxn, nullptr);
   int nproc = PyInt_AsLong(nproc_py);
   Py_DECREF(nproc_py);
   Py_DECREF(nproc_fxn);


### PR DESCRIPTION
Updated sst-macro to be compatible with sst-core changes. 
Some of this many not be ideal. By removing some of the sst/core/serialization/serialize_serializable.h, from core I had to adjust how the sst-macro serialization stuff is implemented. 
Also added some updates for python 3.9+ compatability. 

Definitely not a perfect fix, but it's a starting point. 
